### PR TITLE
[BUGFIX] Corriger le lancement de la CI

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,10 +1,9 @@
 name: Check ESLint
 
 on:
-  push:
-    pull_request:
-      branches:
-        - '**'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   eslint:

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -1,10 +1,9 @@
 name: Check tests
 
 on:
-  push:
-    pull_request:
-      branches:
-        - '**'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   vitest:


### PR DESCRIPTION
## Problème

Les actions GitHubs se lançaient systématiquement à chaque push. Cela demande des ressources inutilement exploitées.

## Solution

Mettre la directive d'exécution à pull-request uniquement.

## Remarque

Si on a:
```yml
on:
	push:
		pull_request
```
Cela exécute l'action sur les pushes et pull requests.