### PR TITLE
[FEATURE] Ajouter le reste des préférences

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -89,6 +89,29 @@
             "credit_words": "Credit words",
             "lyrics": "Lyrics",
             "karaoke": "Karaoke"
+        },
+        "speech": {
+            "title": "Synthesis",
+            "volume_headphone": "Headphone volume",
+            "volume_hp": "Speaker volume",
+            "speed": "Speed",
+            "synthesis": "Synthesizer"
+        },
+        "radio": {
+            "title": "Audio",
+            "volume_headphone": "Headphone volume",
+            "volume_hp": "Speaker volume"
+        },
+        "agenda": {
+            "title": "Agenda",
+            "default_presentation": "Default presentation",
+            "remember": "Remind the events to do"
+        },
+        "braille_learning": {
+            "title": "Write word and operation",
+            "use_vocal": "Use voice synthesis",
+            "keep_spaces": "Preserve the spaces",
+            "write_all": "Write everything"
         }
     },
     "settingsValues": {
@@ -120,7 +143,20 @@
         "no": "No",
         "after_each_note": "After each note",
         "before_each_section": "Before each section",
-        "after_each_section": "After each section"
+        "after_each_section": "After each section",
+        "picotts": "Picots",
+        "mbrola": "Mbrola",
+        "cerence": "Cerence",
+        "espeak": "Espeak",
+        "standard": "Standard",
+        "not_done": "Not done",
+        "today": "Today",
+        "calendar": "Calendar",
+        "same": "The same day",
+        "tomorrow": "The next day",
+        "same_tomorrow": "The same day and the next",
+        "auto": "Automatically",
+        "ask": "On request"
     },
     "settingsPage": {
         "title": "Settings B.note management",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -96,6 +96,29 @@
       "credit_words": "Texte hors musique",
       "lyrics": "Paroles",
       "karaoke": "Karaoké"
+    },
+    "speech": {
+      "title": "Synthèse",
+      "volume_headphone": "Volume des écouteurs",
+      "volume_hp": "Volume des haut-parleurs",
+      "speed": "Vitesse",
+      "synthesis": "Synthétiseur"
+    },
+    "radio": {
+      "title": "Audio",
+      "volume_headphone": "Volume des écouteurs",
+        "volume_hp": "Volume des haut-parleurs"
+    },
+    "agenda": {
+      "title": "Agenda",
+      "default_presentation": "Présentation par défaut",
+      "remember": "Rappeler les événements à faire"
+    },
+    "braille_learning": {
+      "title": "Ecrire mot et opération",
+      "use_vocal": "Utiliser la synthèse vocal",
+      "keep_spaces": "Conserver les espaces",
+      "write_all": "Tout écrire"
     }
   },
   "settingsValues": {
@@ -127,7 +150,21 @@
     "no": "Non",
     "after_each_note": "Après chaque note",
     "before_each_section": "Avant chaque section",
-    "after_each_section": "Après chaque section"
+    "after_each_section": "Après chaque section",
+    "picotts": "Picots",
+    "mbrola": "Mbrola",
+    "cerence": "Cerence",
+    "espeak": "Espeak",
+    "standard": "Standard",
+    "not_done": "Non fait",
+    "today": "Aujourd'hui",
+    "calendar": "Calendrier",
+    "no": "Jamais",
+    "same": "Le jour même",
+    "tomorrow": "Le jour suivant",
+    "same_tomorrow": "Le jour même et le suivant",
+    "auto": "Automatiquement",
+    "ask": "Sur demande"
   },
   "settingsPage": {
     "title": "Gestion des préférences du B.note",

--- a/locales/it.json
+++ b/locales/it.json
@@ -96,6 +96,29 @@
             "credit_words": "Testo fuori dalla musica",
             "lyrics": "Testi",
             "karaoke": "Karaoke"
+        },
+        "speech": {
+            "title": "Sintesi",
+            "volume_headphone": "Volume delle cuffie",
+            "volume_hp": "Volume degli altoparlanti",
+            "speed": "Velocità",
+            "synthesis": "Sintetizzatore"
+        },
+        "radio": {
+            "title": "Audio",
+            "volume_headphone": "Volume delle cuffie",
+            "volume_hp": "Volume degli altoparlanti"
+        },
+        "agenda": {
+            "title": "Agenda",
+            "default_presentation": "Presentazione di default",
+            "remember": "Ricordare gli eventi da fare"
+        },
+        "braille_learning": {
+            "title": "Scrivere parola e operazione",
+            "use_vocal": "Utilizzare la sintesi vocale",
+            "keep_spaces": "Conservare gli spazi",
+            "write_all": "Scrivere tutto"
         }
     },
     "settingsValues": {
@@ -127,7 +150,20 @@
         "no": "No",
         "after_each_note": "Dopo ogni nota",
         "before_each_section": "Prima di ogni sezione",
-        "after_each_section": "Dopo ogni sezione"
+        "after_each_section": "Dopo ogni sezione",
+        "picotts": "Picots",
+        "mbrola": "Mbrola",
+        "cerence": "Cerence",
+        "espeak": "Espeak",
+        "standard": "Standard",
+        "not_done": "Non fatto",
+        "today": "Oggi",
+        "calendar": "Calendario",
+        "same": "Il giorno stesso",
+        "tomorrow": "Il giorno dopo",
+        "same_tomorrow": "Il giorno stesso e il giorno successivo",
+        "auto": "Automaticamente",
+        "ask": "Su richiesta"
     },
     "settingsPage": {
         "title": "Gestione delle preferenze del B.note",

--- a/src/settings.js
+++ b/src/settings.js
@@ -374,6 +374,83 @@ const all_settings = {
       default: true,
     },
   },
+  speech: {
+    volume_headphone: {
+      id: "volume_headphone",
+      type: "number",
+      min: 0,
+      max: 100,
+      default: 50,
+    },
+    volume_hp: {
+      id: "volume_hp",
+      type: "number",
+      min: 0,
+      max: 100,
+      default: 50,
+    },
+    speed: {
+      id: "speed",
+      type: "number",
+      min: 40,
+      max: 240,
+      default :100,
+    },
+    synthesis: {
+      id: "synthesis",
+      type: "menu",
+      values: ["picotts", "mbrola", "espeak", "cerence"],
+      default: "cerence",
+    },
+  },
+  radio: {
+    volume_headphone: {
+      id: "volume_headphone",
+      type: "number",
+      min: 0,
+      max: 100,
+      default: 50,
+    },
+    volume_hp: {
+      id: "volume_hp",
+      type: "number",
+      min: 0,
+      max: 100,
+      default: 50,
+    },
+  },
+  agenda: {
+    default_presentation: {
+      id: "default_presentation",
+      type: "menu",
+      values: ["standard", "not_done", "today", "calendar"],
+      default: "standard",
+    },
+    remember: {
+      id: "remember",
+      type: "menu",
+      values: ["no", "same", "tomorrow", "same_tomorrow"],
+      default: "no",
+    },
+  },
+  braille_learning: {
+    use_vocal: {
+      id: "use_vocal",
+      type: "menu",
+      values: ["auto", "ask", "no"],
+      default: "auto",
+    },
+    keep_spaces: {
+      id: "keep_spaces",
+      type: "checkbox",
+      default: false,
+    },
+    write_all: {
+      id: "write_all",
+      type: "checkbox",
+      default: false,
+    },
+  },
 };
 
 export default all_settings;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -21,6 +21,10 @@ export default {
         explorer: false,
         editor: false,
         music: false,
+        speech: false,
+        radio: false,
+        agenda: false,
+        braille_learning: false,
       },
     };
   },
@@ -165,6 +169,58 @@ export default {
               @setting-change="save_new_value('music_bxml', setting['id'], $event)"
             />
           </div>
+        </div>
+      </div>
+      <!-- Musique -->
+      <div id="speech">
+        <h3>{{$t('settingsName.speech.title')}}</h3>
+        <button type="button" @click="togle_menu('speech')">{{display_menu['speech'] ? $t('settingsPage.hide') : $t('settingsPage.show')}}</button>
+        <div class="setting" v-if="display_menu['speech']">
+          <SettingComponent v-for="setting in all_settings['speech']" :key="setting['id']"
+                            :setting="setting"
+                            :setting_value="settingsData['speech'][setting['id']]"
+                            :name="$t(`settingsName.speech.${setting['id']}`)"
+                            @setting-change="save_new_value('speech', setting['id'], $event)"
+          />
+        </div>
+      </div>
+      <!-- Audio -->
+      <div id="Audio">
+        <h3>{{$t('settingsName.radio.title')}}</h3>
+        <button type="button" @click="togle_menu('radio')">{{display_menu['radio'] ? $t('settingsPage.hide') : $t('settingsPage.show')}}</button>
+        <div class="setting" v-if="display_menu['radio']">
+          <SettingComponent v-for="setting in all_settings['radio']" :key="setting['id']"
+                            :setting="setting"
+                            :setting_value="settingsData['radio'][setting['id']]"
+                            :name="$t(`settingsName.radio.${setting['id']}`)"
+                            @setting-change="save_new_value('radio', setting['id'], $event)"
+          />
+        </div>
+      </div>
+      <!-- Agenda -->
+      <div id="agenda">
+        <h3>{{$t('settingsName.agenda.title')}}</h3>
+        <button type="button" @click="togle_menu('agenda')">{{display_menu['agenda'] ? $t('settingsPage.hide') : $t('settingsPage.show')}}</button>
+        <div class="setting" v-if="display_menu['agenda']">
+          <SettingComponent v-for="setting in all_settings['agenda']" :key="setting['id']"
+                            :setting="setting"
+                            :setting_value="settingsData['agenda'][setting['id']]"
+                            :name="$t(`settingsName.agenda.${setting['id']}`)"
+                            @setting-change="save_new_value('agenda', setting['id'], $event)"
+          />
+        </div>
+      </div>
+      <!-- Braille Learning -->
+      <div id="braille_learning">
+        <h3>{{$t('settingsName.braille_learning.title')}}</h3>
+        <button type="button" @click="togle_menu('braille_learning')">{{display_menu['braille_learning'] ? $t('settingsPage.hide') : $t('settingsPage.show')}}</button>
+        <div class="setting" v-if="display_menu['braille_learning']">
+          <SettingComponent v-for="setting in all_settings['braille_learning']" :key="setting['id']"
+                            :setting="setting"
+                            :setting_value="settingsData['braille_learning'][setting['id']]"
+                            :name="$t(`settingsName.braille_learning.${setting['id']}`)"
+                            @setting-change="save_new_value('braille_learning', setting['id'], $event)"
+          />
         </div>
       </div>
       <button type="submit">{{$t('settingsPage.download')}}</button>


### PR DESCRIPTION
## Problème

Jusqu'à présent, on avait pas toutes les préférences en raison du déploiement progressif du site.

## Solution

Ajouter le reste des préférences en mettant en place le même système que pour les paramètres précédents.

## Remarque

La connexion avec Eole ne peut pas être incluse de notre côté en raison du cryptage..