### PR TITLE
[FEATURE] Ajouter un bouton pour avoir le modèle par défaut

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -165,7 +165,8 @@
         "hide": "Reduce the section",
         "title2": "Settings file",
         "download": "Download file",
-        "openOther": "Open an other file"
+        "openOther": "Open an other file",
+        "create": "Show the default model"
     },
     "title": "B.note management",
     "languages": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -173,6 +173,7 @@
     "show": "Développer la section",
     "hide": "Réduire la section",
     "download": "Télécharger le fichier",
-    "openOther": "Ouvrir un autre fichier"
+    "openOther": "Ouvrir un autre fichier",
+    "create": "Afficher le modèle par défaut"
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -172,6 +172,7 @@
         "hide": "Riduci la sezione",
         "title2": "File delle preferenze",
         "download": "Scaricare il file",
-        "openOther": "Aprire un altro file"
+        "openOther": "Aprire un altro file",
+        "create": "Visualizzare il modello predefinito"
     }
 }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -52,6 +52,17 @@ export default {
         }
       }
     },
+    createBasicData() {
+      const data = {};
+      for (let section in this.all_settings) {
+        data[section] = {};
+        for (let setting in this.all_settings[section]) {
+          data[section][setting] = this.all_settings[section][setting].default;
+        }
+      }
+      this.settingsData=data;
+      this.fileIsImported = true;
+    },
     togle_menu(key) {
       this.display_menu[key] = !this.display_menu[key];
     },
@@ -103,6 +114,8 @@ export default {
   <div v-if="!fileIsImported">
     <p>{{$t('settingsPage.message')}}</p>
     <UploadFileComponent ref="upload" @file-uploaded="get_data" />
+    <hr/>
+    <button type="button" @click="createBasicData">{{$t('settingsPage.create')}}</button>
   </div>
   <div v-if="fileIsImported">
     <h2>{{$t('settingsPage.title2')}}</h2>


### PR DESCRIPTION
## Problème

Lorsqu'on se rendait sur la page, on devait forcément ouvrir un fichier existant pour pouvoir le modifier.

## Solution

Ajouter un bouton permettant d'avoir le modèle avec les paramètres par défaut.