### PR TITLE
[BUGFIX] Ajouter la valeur par défaut pour l'avance de l'afficheur

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -147,6 +147,7 @@ const all_settings = {
       id: "forward_display_mode",
       type: "menu",
       values: ["normal", "significative"],
+      default: "normal",
     },
     "autoscroll": {
       id: "autoscroll",


### PR DESCRIPTION
## Problème

Par défaut, la valeur d'avance de l'afficheur n'apparaissait pas dans la page.

## Solution

Elle n'était pas présente, a été rajouté. Fixes #29