### PR TITLE
[BUGFIX] Remove <strong> in translation files

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,14 +1,14 @@
 {
   "home": {
-    "message-1": "Welcome to the site dedicated to <strong>B.note</strong>. On this site, you will find useful resources for <strong>B.note</strong>, as well as a settings management interface.",
+    "message-1": "Welcome to the site dedicated to B.NOTE. On this site, you will find useful resources for B.NOTE, as well as a settings management interface.",
     "goto-settings": "Go to the interface management",
     "title": "Home"
   },
   "download": {
     "title": "B.note download",
-    "message-1": "Since version 3.0.0 of <strong>B.note</strong>, the source code is free and available on <a href='https://github.com/devel-erb/bnote'>GitHub</a>. Download the image below.",
+    "message-1": "Since version 3.0.0 of B.NOTE, the source code is free and available on <a href='https://github.com/devel-erb/bnote'>GitHub</a>. Download the image below.",
     "eurobrailleTitle": "Eurobraille website",
-    "message2": "The official version of <strong>B.note</strong> is available on the Eurobraille website. You can download it from the site.",
+    "message2": "The official version of B.NOTE is available on the Eurobraille website. You can download it from the site.",
     "downloadEurobraille": "Download the version of Eurobraille",
     "otherTitle": "Other version",
     "message3": "I provide another version whose source code is available <a href=\"https://github.com/theotime2005/bnote\">Here</a>. You can download it below",
@@ -139,7 +139,7 @@
   },
   "settingsPage": {
     "title": "Settings B.note management",
-    "message": "Welcome to the <strong>B.note</strong> online settings management interface.",
+    "message": "Welcome to the B.NOTE online settings management interface.",
     "show": "Expand the section",
     "hide": "Reduce the section",
     "title2": "Settings file",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -8,14 +8,14 @@
   },
   "home": {
     "title": "Accueil",
-    "message-1": "Bienvenue sur le site dédié au <strong>B.note</strong>. Sur ce site, vous trouverez des ressources utiles au <strong>B.note</strong>, ainsi qu'une interface de gestion des préférences.",
+    "message-1": "Bienvenue sur le site dédié au B.NOTE. Sur ce site, vous trouverez des ressources utiles au B.NOTE, ainsi qu'une interface de gestion des préférences.",
     "goto-settings": "Accéder à l'interface de gestion"
   },
   "download": {
     "title": "Téléchargement B.note",
-    "message-1": "Depuis la version 3.0.0 de <strong>B.note</strong>, le code source est libre et disponible sur <a href='https://github.com/devel-erb/bnote'>GitHub</a>. Téléchargez l'image ci-dessous.",
+    "message-1": "Depuis la version 3.0.0 de B.NOTE, le code source est libre et disponible sur <a href='https://github.com/devel-erb/bnote'>GitHub</a>. Téléchargez l'image ci-dessous.",
     "eurobrailleTitle": "Site d'Eurobraille",
-    "message2": "La version officielle de <strong>B.note</strong> est disponible sur le site d'Eurobraille. Vous pouvez la télécharger sur le site.",
+    "message2": "La version officielle de B.NOTE est disponible sur le site d'Eurobraille. Vous pouvez la télécharger sur le site.",
     "downloadEurobraille": "Télécharger la version d'Eurobraille",
     "otherTitle": "Autre version",
     "message3": "Je mets à disposition une autre version dont le code source est disponible <a href=\"https://github.com/theotime2005/bnote\">Ici</a>. Vous pouvez la télécharger ci-dessous",
@@ -147,7 +147,7 @@
   },
   "settingsPage": {
     "title": "Gestion des préférences du B.note",
-    "message": "Bienvenue sur l'interface en ligne de gestion des paramètres de <strong>B.note</strong>.",
+    "message": "Bienvenue sur l'interface en ligne de gestion des paramètres de B.NOTE.",
     "title2": "Fichier de préférences",
     "show": "Développer la section",
     "hide": "Réduire la section",

--- a/locales/it.json
+++ b/locales/it.json
@@ -8,14 +8,14 @@
     },
     "home": {
         "title": "Home",
-        "message-1": "Benvenuto nel sito dedicato al <strong>B.note</strong>. Su questo sito troverai risorse utili per il <strong>B.note</strong>, oltre a un'interfaccia di gestione delle preferenze.",
+        "message-1": "Benvenuto nel sito dedicato al B.NOTE. Su questo sito troverai risorse utili per il B.NOTE, oltre a un'interfaccia di gestione delle preferenze.",
         "goto-settings": "Accedi all'interfaccia di gestione"
     },
     "download": {
         "title": "Download B.note",
-        "message-1": "Dalla versione 3.0.0 di <strong>B.note</strong>, il codice sorgente è libero e disponibile su <a href='https://github.com/devel-erb/bnote'>GitHub</a>. Scarica l'immagine qui sotto.",
+        "message-1": "Dalla versione 3.0.0 di B.NOTE, il codice sorgente è libero e disponibile su <a href='https://github.com/devel-erb/bnote'>GitHub</a>. Scarica l'immagine qui sotto.",
         "eurobrailleTitle": "Sito di Eurobraille",
-        "message2": "La versione ufficiale di <strong>B.note</strong> è disponibile sul sito di Eurobraille. Puoi scaricarla dal sito.",
+        "message2": "La versione ufficiale di B.NOTE è disponibile sul sito di Eurobraille. Puoi scaricarla dal sito.",
         "downloadEurobraille": "Scarica la versione di Eurobraille",
         "otherTitle": "Altra versione",
         "message3": "Metto a disposizione un'altra versione il cui codice sorgente è disponibile <a href=\"https://github.com/theotime2005/bnote\">qui</a>. Puoi scaricarla qui sotto",
@@ -148,7 +148,7 @@
     },
     "settingsPage": {
         "title": "Gestione delle preferenze del B.note",
-        "message": "Benvenuto nell'interfaccia online di gestione delle impostazioni di <strong>B.note</strong>.",
+        "message": "Benvenuto nell'interfaccia online di gestione delle impostazioni di B.NOTE.",
         "show": "Espandi la sezione",
         "hide": "Riduci la sezione",
         "title2": "File delle preferenze",


### PR DESCRIPTION
## Problem

strong html tags do not pass through translation files.

## Solution

Write B.NOTE rather than B.note.