### PR TITLE
[TECH] Add a test for translations

### DIFF
--- a/Contribution guide.md
+++ b/Contribution guide.md
@@ -35,3 +35,4 @@ cd locale
 node update_translation.cjs <base_language> <target_language>
 ```
 New translations will be marked with a "*".
+NOTE: tests include a translation checking, based on french language.

--- a/src/__tests__/translations.test.js
+++ b/src/__tests__/translations.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const localesDir = path.resolve(__dirname, "../../locales");
+const baseLang = "fr";
+
+function loadTranslations(lang) {
+  const filePath = path.join(localesDir, `${lang}.json`);
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function checkTranslations(baseTranslations, targetTranslations, lang) {
+  for (const key in baseTranslations) {
+    if (!Object.prototype.hasOwnProperty.call(targetTranslations, key)) {
+      console.log(`Missing key '${key}' in ${lang}`);
+      return false;
+    }
+    if (typeof baseTranslations[key] === "object") {
+      if (!checkTranslations(baseTranslations[key], targetTranslations[key], lang)) {
+        return false;
+      }
+    } else {
+      if (targetTranslations[key].startsWith("*")) {
+        console.log(`Untranslated key '${key}' in ${lang}`);
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+describe("Translation files", () => {
+  const baseTranslations = loadTranslations(baseLang);
+  const files = fs.readdirSync(localesDir).filter(file => file.endsWith(".json") && file !== `${baseLang}.json`);
+
+  files.forEach(file => {
+    const lang = path.basename(file, ".json");
+    it(`should have up-to-date translations for ${lang}`, () => {
+      const targetTranslations = loadTranslations(lang);
+      expect(checkTranslations(baseTranslations, targetTranslations, lang)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

There was no way to ensure that the site was fully translated into all supported languages.

## Solution

Add a test that will verify that all languages are equal in terms of translation keys.

## Note

This can be a problem for some foreign pr.

## Test

Check that the CI passes correctly.