### PR TITLE
[MAJORFEATURE] Add an about page to the site

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -175,5 +175,16 @@
         "title": "FAQ",
         "presentation": "Welcome to the site's FAQ. This FAQ is different depending on the language selected.",
         "nofaq": "No FAQ available in this language."
+    },
+    "about": {
+        "title": "About website",
+        "message1": "This site was created in 2024 by Théotime Berthod. Its source code is free on GitHub.",
+        "contribution": "Do you want to contribute?",
+        "message2": "If you are a developer and want to join the adventure, do not hesitate any longer. We will always be happy to see the site enriched with new features",
+        "github": "View the source code on GitHub",
+        "feature-bug": "An idea or a bug?",
+        "message3": "Do not hesitate to send us any suggestions or problems via GitHub.",
+        "feature": "Suggest a new feature",
+        "bug_report": "Report a bug"
     }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -174,5 +174,16 @@
     "title": "FAQ",
     "presentation": "Bienvenue sur la FAQ du site. Cette FAQ est différentes selon la langue sélectionnée.",
     "nofaq": "Pas de FAQ disponible dans cette langue."
+  },
+  "about": {
+    "title": "A propos du site",
+    "message1": "Ce site a été créé en 2024 par Théotime Berthod. Son code source est libre sur GitHub.",
+    "contribution": "Vous souhaitez contribuer ?",
+    "message2": "Si vous êtes développeur ou développeuse et que vous souhaitez rejoindre l'aventure, n'hésitez plus. Nous serons toujours heureux de voir le site s'enrichir de nouvelles fonctionalités",
+    "github": "Voir le code source sur GitHub",
+    "feature-bug": "Une idée ou un bug ?",
+    "message3": "N'hésitez pas à nous faire remonter toutes suggestions ou problème via GitHub.",
+    "feature": "Suggérer une nouvelle fonctionnalité",
+    "bug_report": "Signaler un bug"
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -175,5 +175,16 @@
         "title": "Domande frequenti",
         "presentation": "Benvenuto nelle FAQ del sito. Questa FAQ è diversa a seconda della lingua selezionata.",
         "nofaq": "Nessuna FAQ disponibile in questa lingua."
+    },
+    "about": {
+        "title": "A proposito del sito",
+        "message1": "Questo sito è stato creato nel 2024 da Théotime Berthod. Il suo codice sorgente è libero su GitHub.",
+        "contribution": "Desidera contribuire?",
+        "message2": "Se sei uno sviluppatore o una sviluppatrice e vuoi unirti all'avventura, non esitare più. Saremo sempre felici di vedere il sito arricchirsi di nuove funzionalità",
+        "github": "Vedere il codice sorgente su GitHub",
+        "feature-bug": "Un'idea o un bug?",
+        "message3": "Non esitate a segnalarci qualsiasi suggerimento o problema tramite GitHub.",
+        "feature": "Suggerire una nuova funzionalità",
+        "bug_report": "Segnalare un bug"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bnote-settings",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bnote-settings",
-      "version": "3.0.0-beta.0",
+      "version": "3.0.0-beta.1",
       "dependencies": {
         "pinia": "^2.1.7",
         "vue": "^3.4.29",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bnote-settings",
-  "version": "2.8.0",
+  "version": "3.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bnote-settings",
-      "version": "2.8.0",
+      "version": "3.0.0-beta.0",
       "dependencies": {
         "pinia": "^2.1.7",
         "vue": "^3.4.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnote-settings",
-  "version": "2.8.0",
+  "version": "3.0.0-beta.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnote-settings",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/router/router-list.js
+++ b/src/router/router-list.js
@@ -20,10 +20,10 @@ const routes = [
     component: () => import("@/views/FaqView.vue"),
   },
   {
-    path: '/about',
+    path: "/about",
     name: "about",
-    component: () => import("@/views/AboutView.vue")
-  }
+    component: () => import("@/views/AboutView.vue"),
+  },
 ];
 
 export default routes;

--- a/src/router/router-list.js
+++ b/src/router/router-list.js
@@ -19,6 +19,11 @@ const routes = [
     name: "faq",
     component: () => import("@/views/FaqView.vue"),
   },
+  {
+    path: '/about',
+    name: "about",
+    component: () => import("@/views/AboutView.vue")
+  }
 ];
 
 export default routes;

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,0 +1,22 @@
+<script>
+export default {
+  name: 'About'
+}
+</script>
+
+<template>
+  <h1>{{$t('about.title')}}</h1>
+  <p>{{$t('about.message1')}}</p>
+  <h2>{{$t('about.contribution')}}</h2>
+  <p>{{$t('about.message2')}}</p>
+  <a href="https://github.com/theotime2005/bnote-settings">{{$t('about.github')}}</a>
+  <h2>{{$t('about.feature-bug')}}</h2>
+  <p>{{$t('about.message3')}}</p>
+  <a href='https://github.com/theotime2005/bnote-settings/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=' target="_blank">{{$t('about.feature')}}</a>
+  <a href='https://github.com/theotime2005/bnote-settings/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=' target="_blank">{{$t('about.bug_report')}}</a>
+
+</template>
+
+<style scoped>
+
+</style>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,7 +1,7 @@
 <script>
 export default {
-  name: 'About'
-}
+  name: "AboutView",
+};
 </script>
 
 <template>


### PR DESCRIPTION
## Problem

There was no page about it with information on the development of the site or how to make reports or suggestions.

## Solution

Add an about page with the following information:

- A brief history of the site,

- A link to the GitHub repository,

- Links to issue templates for features and bugs.

## Note

This information is subject to change.

## Test

Verify that a new about page is present on the site.