### PR TITLE
[BUGFIX] Translate a forgotten message

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -159,7 +159,8 @@
         "defaultName": "Default configuration",
         "downloadName": "Settings {date}",
         "how": "How does it work?",
-        "explication": "You can either create a file directly from the site using the default template or load the file from a device."
+        "explication": "You can either create a file directly from the site using the default template or load the file from a device.",
+        "question": "Do you really want to download the file?"
     },
     "title": "B.note management",
     "languages": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -168,7 +168,8 @@
     "create": "Afficher le modèle par défaut",
     "downloadName": "Préférence {date}",
     "how": "Comment ça marche?",
-    "explication": "Vous pouvez soit créer un fichier directement à partir du site en utilisant le modèle par défaut, soit charger le fichier d'un appareil."
+    "explication": "Vous pouvez soit créer un fichier directement à partir du site en utilisant le modèle par défaut, soit charger le fichier d'un appareil.",
+    "question": "Voulez-vous vraiment télécharger le fichier ?"
   },
   "faq": {
     "title": "FAQ",

--- a/locales/it.json
+++ b/locales/it.json
@@ -166,7 +166,8 @@
         "defaultName": "Configurazione di default",
         "downloadName": "Preferenza {data}",
         "how": "Come funziona?",
-        "explication": "È possibile creare un file direttamente dal sito utilizzando il modello predefinito o caricare il file da un dispositivo."
+        "explication": "È possibile creare un file direttamente dal sito utilizzando il modello predefinito o caricare il file da un dispositivo.",
+        "question": "Vuoi davvero scaricare il file?"
     },
     "header": {
         "mainMenu": "Menu principale"

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -75,7 +75,7 @@ export default {
       this.settingsData[section][key] = new_value;
     },
     save() {
-      const question = window.confirm("Voulez-vous vraiment télécharger le fichier?");
+      const question = window.confirm(this.$t("settingsPage.question"));
       return question ? this.download_file() : null;
     },
     download_file() {


### PR DESCRIPTION
## Problem

In the settings management page, the message regarding the download issue was not translated during the internationalization of the site.

## Solution

Add this message in the translations and replace the hard message in the code with the appropriate key.

## Test

- Go to the settings management page,

- Display the default model,

- Check that in each language, when you click on the `download` button, the confirmation message is displayed in the correct language.