### PR TITLE
[TECH] Launch the CodeQL workflow with each push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "main" ]
   schedule:


### PR DESCRIPTION
## Problem

The CodeQL workflow only started on pull requests or on the main branch.

## Solution

Launch the workflow on each branch at a push.