### PR TITLE
[BUGFIX] Proposer les versions définitive uniquement au téléchargement

### DIFF
--- a/src/views/DownloadPageView.vue
+++ b/src/views/DownloadPageView.vue
@@ -11,8 +11,13 @@ export default {
       try {
         const request = await fetch("https://api.github.com/repos/theotime2005/bnote/releases");
         const response = await request.json();
-        const version = response[0];
-        console.log(version);
+        let version = null;
+        for (let i = 0; i < response.length; i++) {
+          if (response[i]["prerelease"] === false) {
+            version = response[i];
+            break;
+          }
+        }
         this.last_version["tag"] = version["tag_name"];
         this.last_version["file"] = version["assets"][0]["browser_download_url"];
       } catch (e) {


### PR DESCRIPTION
## Problem

On the download page, the latest available version was displayed, regardless of whether it was prereleased or not. However, we cannot offer prerelease versions on the site.

## Solution

Add a loop that does a check.

## Test

- Go to the download page,

- Note that the proposed version is not a pre-version.