### PR TITLE
[MINORFEATURE] Add the button setting at the beginning of the dialog box

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -100,7 +100,8 @@
         "bnote_visible": "Make detectable",
         "bnote_name": "Device name",
         "bt_simul_esys": "Esys simulation mode",
-        "timezone": "Time zone"
+        "timezone": "Time zone",
+        "button_in_first": "Button in first in message dialog box"
     },
     "settingsValues": {
         "dot-8": "Dot 8",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -45,6 +45,7 @@
     "braille_type": "Type de braille",
     "auto_sync_date": "Synchronisation automatique de la date",
     "spaces_in_label": "Espaces dans les labels",
+    "button_in_first": "Bouton au début des boîtes dialogue de message",
     "shortcuts_visible": "Raccourcis visibles",
     "app_explorer": "Afficher l'app Explorateur",
     "app_settings": "Afficher l'app Préférences",

--- a/locales/it.json
+++ b/locales/it.json
@@ -107,7 +107,8 @@
         "bnote_visible": "Rendere rilevabile",
         "bnote_name": "Nome dell'apparecchio",
         "bt_simul_esys": "Simulazione della modalità Esys",
-        "timezone": "Fuso orario"
+        "timezone": "Fuso orario",
+        "button_in_first": "Pulsanto all'inizio delle finestre di dialogo dei messaggi"
     },
     "settingsValues": {
         "dot-8": "Braille informatico (8 punti)",

--- a/src/settings.js
+++ b/src/settings.js
@@ -16,6 +16,11 @@ const all_settings = {
       type: "checkbox",
       default: false,
     },
+    "button_in_first": {
+      id: "button_in_first",
+      type: "checkbox",
+      default: true,
+    },
     "shortcuts_visible": {
       id: "shortcuts_visible",
       type: "checkbox",


### PR DESCRIPTION
## Problem

A new parameter will appear. It allows you to display or not the buttons at the beginning of the B.note dialog boxes (for those of the message or info type only).

## Solution

Add this setting to the settings file.

## Note

Wouldn't it be interesting to put the parameters in a .json file rather than in a .js file?

## Test

- Go to the management page,

- Note that the new parameter is present.