### PR TITLE
[TECH] Rewrite tests with helper

### DIFF
--- a/src/__tests__/components/FooterComponent.spec.js
+++ b/src/__tests__/components/FooterComponent.spec.js
@@ -1,49 +1,32 @@
 import { describe, it, expect } from "vitest";
-import { mount } from "@vue/test-utils";
 import i18n from "@/i18n.js";
 import FooterComponent from "@/components/FooterComponent.vue";
-import packageInfo from "../../../package.json";
+import { render, t } from "../helpers";
 
-const t = i18n.global.t;
 describe("FooterComponent", () => {
   it("renders footer messages correctly", () => {
-    const wrapper = mount(FooterComponent, {
-      global: {
-        mocks: {
-          $t: (msg) => t(msg),
-          $i18n: i18n,
-        },
+    const wrapper = render(FooterComponent, {
+      mocks: {
+        $i18n: i18n,
       },
     });
     expect(wrapper.text()).toContain(t("footer.message1"));
     expect(wrapper.text()).toContain(t("footer.message2"));
   });
 
-  it("renders the correct version from package.json", () => {
-    const wrapper = mount(FooterComponent, {
-      global: {
-        mocks: {
-          $t: (msg, option) => {
-            if (msg === "footer.version") {
-              return t("footer.version", { version: option });
-            } else {
-              return t(msg);
-            }
-          },
-          $i18n: i18n,
-        },
+  it("renders the version info", () => {
+    const wrapper = render(FooterComponent, {
+      mocks: {
+        $i18n: i18n,
       },
     });
-    expect(wrapper.text()).toContain(packageInfo.version);
+    expect(wrapper.text()).toContain(t("footer.version"));
   });
 
   it("renders the GitHub link correctly", () => {
-    const wrapper = mount(FooterComponent, {
-      global: {
-        mocks: {
-          $t: (msg) => msg,
-          $i18n: i18n,
-        },
+    const wrapper = render(FooterComponent, {
+      mocks: {
+        $i18n: i18n,
       },
     });
     const link = wrapper.find("a");
@@ -52,12 +35,9 @@ describe("FooterComponent", () => {
   });
 
   it("contains LanguageComponent", () => {
-    const wrapper = mount(FooterComponent, {
-      global: {
-        mocks: {
-          $t: (msg) => t(msg),
-          $i18n: i18n,
-        },
+    const wrapper = render(FooterComponent, {
+      mocks: {
+        $i18n: i18n,
       },
     });
     expect(wrapper.findComponent({ name: "LanguageComponent" }).exists()).toBe(true);

--- a/src/__tests__/components/LanguageComponent.spec.js
+++ b/src/__tests__/components/LanguageComponent.spec.js
@@ -1,31 +1,23 @@
-import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import LanguageComponent from "@/components/LanguageComponent.vue";
+import { render } from "../helpers";
 
 describe("LanguageComponent", () => {
   it("devrait définir la langue actuelle au montage", () => {
     const $i18n = { locale: "en", availableLocales: ["en", "fr"] };
-    const wrapper = mount(LanguageComponent, {
-      global: {
-        mocks: {
-          $i18n,
-          $t: (msg) => msg,
-        },
+    const wrapper = render(LanguageComponent, {
+      mocks: {
+        $i18n,
       },
     });
-
-    expect(wrapper.vm.current_language).toBe("en");
+    expect(wrapper.vm.current_language).toBe($i18n.locale);
   });
 
   it("devrait changer la langue quand une nouvelle langue est sélectionnée", async () => {
     const $i18n = { locale: "en", availableLocales: ["en", "fr"] };
-    const wrapper = mount(LanguageComponent, {
-      global: {
-        mocks: {
-          $i18n,
-          $t: (msg) => msg,
-
-        },
+    const wrapper = render(LanguageComponent, {
+      mocks: {
+        $i18n,
       },
     });
 
@@ -39,9 +31,9 @@ describe("LanguageComponent", () => {
 
   it("devrait afficher les options de langues correctement", () => {
     const $i18n = { locale: "en", availableLocales: ["en", "fr"] };
-    const wrapper = mount(LanguageComponent, {
-      global: {
-        mocks: { $i18n, $t: (msg) => msg },
+    const wrapper = render(LanguageComponent, {
+      mocks: {
+        $i18n,
       },
     });
 

--- a/src/__tests__/components/NaveBarreComponent.spec.js
+++ b/src/__tests__/components/NaveBarreComponent.spec.js
@@ -1,60 +1,53 @@
 import { describe, it, expect } from "vitest";
-import { shallowMount, RouterLinkStub } from "@vue/test-utils";
 import NaveBarreComponent from "@/components/NaveBarreComponent.vue";
 import routes from "@/router/router-list.js";
+import { createRouter, createWebHistory } from "vue-router";
+import { render } from "@/__tests__/helpers";
 
 describe("NaveBarreComponent", () => {
-  it("renders a menu item for each route", () => {
-    const wrapper = shallowMount(NaveBarreComponent, {
-      global: {
-        components: {
-          RouterLink: RouterLinkStub,
-        },
-        mocks: {
-          $t: (msg) => msg,
-        },
-      },
+  // Créez une instance de routeur avec les routes définies
+  const router = createRouter({
+    history: createWebHistory(),
+    routes,
+  });
+
+  it("renders a menu item for each route", async () => {
+    const wrapper = render(NaveBarreComponent, {
+      plugins: [router],
     });
-    const menuItems = wrapper.findAllComponents(RouterLinkStub);
+
+    // Attendez que le routeur soit prêt
+    await router.isReady();
+
+    const menuItems = wrapper.findAllComponents({ name: "RouterLink" });
     expect(menuItems.length).toBe(routes.length);
   });
 
-  it("renders the correct route paths", () => {
-    const wrapper = shallowMount(NaveBarreComponent, {
-      global: {
-        components: {
-          RouterLink: RouterLinkStub,
-        },
-        mocks: {
-          $t: (msg) => msg,
-        },
-      },
+  it("renders the correct route paths", async () => {
+    const wrapper = render(NaveBarreComponent, {
+      plugins: [router],
     });
-    const menuItems = wrapper.findAllComponents(RouterLinkStub);
+
+    await router.isReady();
+
+    const menuItems = wrapper.findAllComponents({ name: "RouterLink" });
     if (menuItems.length > 0) {
       menuItems.forEach((item, index) => {
-        expect(item.attributes("to")).toBe(routes[index].path);
+        expect(item.props("to")).toBe(routes[index].path);
       });
     }
   });
 
-  it("handles empty routes array", () => {
-    const wrapper = shallowMount(NaveBarreComponent, {
-      data() {
-        return {
-          routes: [],
-        };
-      },
-      global: {
-        components: {
-          RouterLink: RouterLinkStub,
-        },
-        mocks: {
-          $t: (msg) => msg,
-        },
-      },
+  it("handles empty routes array", async () => {
+    const wrapper = render(NaveBarreComponent, {
+      plugins: [router],
+    }, {}, {
+      routes: [],
     });
-    const menuItems = wrapper.findAllComponents(RouterLinkStub);
+
+    await router.isReady();
+
+    const menuItems = wrapper.findAllComponents({ name: "RouterLink" });
     expect(menuItems.length).toBe(0);
   });
 });

--- a/src/__tests__/components/SettingComponent.spec.js
+++ b/src/__tests__/components/SettingComponent.spec.js
@@ -1,23 +1,16 @@
-import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
 import SettingComponent from "@/components/SettingComponent.vue";
+import { render } from "@/__tests__/helpers.js";
 
 describe("SettingComponent.vue", () => {
 
   // Test pour l'input checkbox
   it("devrait rendre une checkbox et émettre l'événement 'setting-change' lors d'une modification", async () => {
-    const wrapper = mount(SettingComponent, {
-      props: {
-        name: "Test Checkbox",
-        label_id: "category.checkbox",
-        setting: { type: "checkbox" },
-        setting_value: true,
-      },
-      global: {
-        mocks: {
-          $t: (msg) => msg,
-        },
-      },
+    const wrapper = render(SettingComponent, {}, {
+      name: "Test Checkbox",
+      label_id: "category.checkbox",
+      setting: { type: "checkbox" },
+      setting_value: true,
     });
 
     // Vérifie que la checkbox est cochée initialement
@@ -37,18 +30,11 @@ describe("SettingComponent.vue", () => {
   // Test pour le dropdown (menu)
   describe("# Test du dropdown", () => {
     it("devrait rendre un menu déroulant et émettre l'événement 'setting-change' lors d'une modification avec traduction", async () => {
-      const wrapper = mount(SettingComponent, {
-        props: {
-          name: "Test Menu",
-          label_id: "category.dropdownmenu",
-          setting: { type: "menu", values: ["option1", "option2", "option3"] },
-          setting_value: "option1",
-        },
-        global: {
-          mocks: {
-            $t: (msg) => msg,
-          },
-        },
+      const wrapper = render(SettingComponent, {}, {
+        name: "Test Menu",
+        label_id: "category.dropdownmenu",
+        setting: { type: "menu", values: ["option1", "option2", "option3"] },
+        setting_value: "option1",
       });
       // Vérifie que la valeur initiale est 'option1'
       const select = wrapper.find("select");
@@ -67,18 +53,11 @@ describe("SettingComponent.vue", () => {
     });
 
     it("devrait rendre un menu déroulant et émettre l'événement 'setting-change' lors d'une modification sans traduction", async () => {
-      const wrapper = mount(SettingComponent, {
-        props: {
-          name: "Test Menu",
-          label_id: "category.dropdownmenu",
-          setting: { type: "menu", values: ["option1", "option2", "option3"], isTranslate: true },
-          setting_value: "option1",
-        },
-        global: {
-          mocks: {
-            $t: (msg) => msg,
-          },
-        },
+      const wrapper = render(SettingComponent, {}, {
+        name: "Test Menu",
+        label_id: "category.dropdownmenu",
+        setting: { type: "menu", values: ["option1", "option2", "option3"], isTranslate: true },
+        setting_value: "option1",
       });
       // Vérifie que la valeur initiale est 'option1'
       const select = wrapper.find("select");
@@ -99,18 +78,11 @@ describe("SettingComponent.vue", () => {
 
   // Test pour l'input number
   it("devrait rendre un champ number et émettre l'événement 'setting-change' lors d'une modification", async () => {
-    const wrapper = mount(SettingComponent, {
-      props: {
-        name: "Test Number",
-        label_id: "category.editbox",
-        setting: { type: "number", min: 1, max: 10 },
-        setting_value: 5,
-      },
-      global: {
-        mocks: {
-          $t: (msg) => msg,
-        },
-      },
+    const wrapper = render(SettingComponent, {}, {
+      name: "Test Number",
+      label_id: "category.editbox",
+      setting: { type: "number", min: 1, max: 10 },
+      setting_value: 5,
     });
 
     // Vérifie que la valeur initiale est '5'
@@ -127,19 +99,12 @@ describe("SettingComponent.vue", () => {
     expect(wrapper.emitted("setting-change")[0]).toEqual([7]);
   });
 
-  it("should Doit afficher le for du label passé en prop", () => {
-    const wrapper = mount(SettingComponent, {
-      props: {
-        name: "Test Checkbox",
-        label_id: "category.checkbox",
-        setting: { type: "checkbox" },
-        setting_value: true,
-      },
-      global: {
-        mocks: {
-          $t: (msg) => msg,
-        },
-      },
+  it("Doit afficher le for du label passé en prop", () => {
+    const wrapper=render(SettingComponent, {}, {
+      name: "Test Checkbox",
+      label_id: "category.checkbox",
+      setting: { type: "checkbox" },
+      setting_value: true,
     });
     expect(wrapper.find("label").attributes("for")).toBe("category.checkbox");
   });

--- a/src/__tests__/components/UploadFileComponent.spec.js
+++ b/src/__tests__/components/UploadFileComponent.spec.js
@@ -1,20 +1,11 @@
-import { mount } from "@vue/test-utils";
 import { describe, it, expect, vi } from "vitest";
-import i18n from "@/i18n.js";
 import UploadFileComponent from "@/components/UploadFileComponent.vue";
-
-const t = i18n.global.t;
+import { render, t } from "@/__tests__/helpers.js";
 
 describe("UploadFileComponent.vue", () => {
   // Test pour vérifier la gestion de la sélection de fichier
   it("devrait gérer correctement la sélection de fichier", async () => {
-    const wrapper = mount(UploadFileComponent, {
-      global: {
-        mocks: {
-          $t: (msg) => t(msg),
-        },
-      },
-    });
+    const wrapper = render(UploadFileComponent);
 
     // Simule un événement de changement de fichier
     const file = new File(["test content"], "test.bnote", { type: "text/plain" });
@@ -31,13 +22,7 @@ describe("UploadFileComponent.vue", () => {
 
   // Test pour vérifier l'alerte si le format de fichier est incorrect
   it("devrait afficher une alerte si le format du fichier est incorrect", async () => {
-    const wrapper = mount(UploadFileComponent, {
-      global: {
-        mocks: {
-          $t: (msg) => t(msg),
-        },
-      },
-    });
+    const wrapper = render(UploadFileComponent);
 
     window.alert = vi.fn(); // Mock de window.alert
 
@@ -60,13 +45,7 @@ describe("UploadFileComponent.vue", () => {
 
   // Test pour vérifier la lecture du fichier et l'émission de l'événement
   it("devrait lire le contenu du fichier et émettre l'événement \"file-uploaded\"", async () => {
-    const wrapper = mount(UploadFileComponent, {
-      global: {
-        mocks: {
-          $t: (msg) => t(msg),
-        },
-      },
-    });
+    const wrapper = render(UploadFileComponent);
 
     const fileContent = JSON.stringify({ message: "hello world" });
     const file = new File([fileContent], "test.bnote", { type: "text/plain" });

--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -1,0 +1,34 @@
+import { mount } from "@vue/test-utils";
+
+const t = (msg) => msg;
+
+const render = (component, global = {}, properties = {}, data = null) => {
+  // Initialize mocks with the default $t mock
+  const defaultMocks = {
+    $t: (msg) => msg,
+  };
+
+  // Fusionner les mocks définis dans `global` avec les mocks par défaut
+  const global_component = {
+    ...global,
+    mocks: {
+      ...defaultMocks,
+      ...(global.mocks || {}), // Ajouter ou fusionner les mocks personnalisés
+    },
+  };
+
+  // Préparer les options pour le montage
+  const mountOptions = {
+    global: global_component,
+    props: properties,
+  };
+
+  // Ajouter l'option `data` si elle est définie
+  if (data) {
+    mountOptions.data = () => data;
+  }
+
+  return mount(component, mountOptions);
+};
+
+export { render, t };


### PR DESCRIPTION
- **feat: Add helper for tests**
- **fix: Rewrite tests with helper**

## Problem
In tests, it must necessary to mock $t for all components. It was longer and repeat same instruction most times.

## Solution

Create a helper file that render component with $t mocks automatically.

## Note

It's ok for this tests, bud for future acceptance tests?

## Test
Check that all tests pass.
