### PR TITLE
[MINORFEATURE] Place the content of the page in a main tag

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,8 +6,8 @@ import FooterComponent from "@/components/FooterComponent.vue";
 
 <template>
   <NaveBarreComponent />
-  <div class="flex flex-col flex-grow overflow-y-scroll">
+  <main class="flex flex-col flex-grow overflow-y-scroll">
     <RouterView />
-  </div>
+  </main>
   <FooterComponent />
 </template>


### PR DESCRIPTION
## Problem

At the entry point of the site, the content of the page was placed in a simple div, which was not convenient for screen readers.

## Solution

Place the view content in a main tag.

## Note

This has no impact on the tests.

## Test

On pages, check that the content is in a main tag