### PR TITLE
[BUGFIX] Change the name of action to publish a new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --ignore-path .gitignore",
     "lint:fix": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
     "format": "prettier --write src/",
-    "publish": "sh script/release.sh",
+    "production": "sh script/release.sh",
     "release": "standard-version"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem
The command publish is allready used by npm.

## Solution

Use this command:
```shell
npm run production
```

## Test
You can't test this changes.