### PR TITLE
[BUGFIX] Correct the command to merge main into production

### DIFF
--- a/.github/workflows/Merge into production.yml
+++ b/.github/workflows/Merge into production.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Merge main into production
         run: |
           git checkout production
-          git merge main --no-ff -m "Merge branch 'main' into 'production'"
+          git merge origin/main --no-ff -m "Merge branch 'main' into 'production'"
 
       - name: Push changes
         run: |


### PR DESCRIPTION
## Problem

THe github workflow doesn't accept the commande:
```shell
git merge main
```

## Solution

Use this commande:
```shell
git merge origin/main
```