### PR TITLE
[TECH] Put the workflow back to generate a new version

### DIFF
--- a/.github/workflows/Build version.yml
+++ b/.github/workflows/Build version.yml
@@ -1,0 +1,39 @@
+# This workflow generates a new version and pushes it to the main branch
+# It runs manually
+
+name: Build version
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload-new-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup node js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+
+      - name: Setup git
+        # The name of this bot is bnote-settings-deployer
+        run: git config --global user.name "bnote-settings-deployer" && git config --global user.email "bnote-settings-deployer@github.com"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build new version
+        # Use standard-version to generate a new version
+        run: npm run release
+
+      - name: Push new version
+        run: git push --follow-tags origin main
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of generating and pushing a new version to the main branch. The workflow is designed to be run manually. Below are the key changes:

New GitHub Actions workflow:

* [`.github/workflows/Build version.yml`](diffhunk://#diff-22a4f6633866c296cdc85f184e7dc749986576390f3d72b4b9752c855d610e73R1-R39): Added a new workflow named "Build version" that runs manually to generate a new version and push it to the main branch. The workflow includes steps for checking out the repository, setting up Node.js, configuring git, installing dependencies, building the new version, and pushing it to the main branch.