### PR TITLE
[BUGFIX] Correct the routing type

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,11 +1,11 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHashHistory } from "vue-router";
 
 import i18n from "@/i18n.js";
 import routesList from "@/router/router-list.js";
 
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes: routesList,
 });
 


### PR DESCRIPTION
This pull request includes a change to the `src/router/index.js` file to switch the router history mode from `createWebHistory` to `createWebHashHistory`.

* [`src/router/index.js`](diffhunk://#diff-3210ca9ed615e6f0fc1743fc09be3c86bc38178dcc050e5a41ff7982d15875b7L1-R8): Changed the router history mode from `createWebHistory` to `createWebHashHistory` to use hash-based routing instead of HTML5 history mode.