### PR TITLE
[TECH] Launch the CI only if the pull request is not in draft

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   eslint:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   vitest:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to ensure that certain jobs only run when the pull request is not in draft mode.

Changes to GitHub Actions workflows:

* [`.github/workflows/check-lint.yml`](diffhunk://#diff-20fe1266f89be6c7574eb75d9d5f94a20068c4d38bc7ea1900074a6a69f7a917R10): Added a condition to the `eslint` job to run only if the pull request is not a draft.
* [`.github/workflows/check-tests.yml`](diffhunk://#diff-e6ca5345641700b84db3333c2e2038a963319137c37cf92fa6c3e214ccb8ede3R10): Added a condition to the `vitest` job to run only if the pull request is not a draft.