### PR TITLE
[TECH] Correct the syntax to launch the CI on the pr that are ready for review

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   eslint:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - ready_for_review
 
 jobs:
   eslint:

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   vitest:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - ready_for_review
 
 jobs:
   vitest:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to trigger jobs only when a pull request is marked as ready for review. The most important changes include updating the `check-lint.yml` and `check-tests.yml` workflows.

Changes to GitHub Actions workflows:

* [`.github/workflows/check-lint.yml`](diffhunk://#diff-20fe1266f89be6c7574eb75d9d5f94a20068c4d38bc7ea1900074a6a69f7a917R7-L10): Added `types: ready_for_review` to trigger the lint job only when the pull request is ready for review and removed the draft check condition.
* [`.github/workflows/check-tests.yml`](diffhunk://#diff-e6ca5345641700b84db3333c2e2038a963319137c37cf92fa6c3e214ccb8ede3R7-L10): Added `types: ready_for_review` to trigger the test job only when the pull request is ready for review and removed the draft check condition.