### PR TITLE
[FEATURE] Create a logger to send logs to an api

### DIFF
--- a/src/__tests__/scripts/send-error-message-script.spec.js
+++ b/src/__tests__/scripts/send-error-message-script.spec.js
@@ -1,0 +1,83 @@
+import { sendLog } from "@/scripts/send-error-message-script.js";
+
+describe("scripts | sendLog", () => {
+  let fetch;
+  let console;
+  beforeEach(() => {
+    fetch = vi.spyOn(global, "fetch").mockResolvedValue({ ok: true });
+    process.env.LOG_API_URL = "http://example.net";
+    console = { log: vi.spyOn(global.console, "log"), error: vi.spyOn(global.console, "error") };
+  });
+
+  afterEach(function () {
+    fetch.mockRestore;
+    console.log.mockRestore;
+  });
+
+  describe("Send a log", () => {
+    it("send a basic log", async () => {
+      // when
+      await sendLog({ fileName: "testFile", functionName: "testFunction", type: "info", log: "Hello World" });
+
+      // then
+      expect(fetch).toHaveBeenCalledWith("http://example.net", expect.any(Object));
+      expect(console.log).toHaveBeenCalled;
+    });
+  });
+
+  describe("Send a log with different types", () => {
+    it("send an error log", async () => {
+      // when
+      await sendLog({ fileName: "testFile", functionName: "testFunction", type: "error", log: "Error occurred" });
+
+      // then
+      expect(fetch).toHaveBeenCalledWith("http://example.net", expect.objectContaining({
+        body: expect.stringContaining("\\\"type\\\": \\\"error\\\""),
+      }));
+    });
+
+    it("send a warning log", async () => {
+      // when
+      await sendLog({ fileName: "testFile", functionName: "testFunction", type: "warning", log: "Warning issued" });
+
+      // then
+      expect(fetch).toHaveBeenCalledWith("http://example.net", expect.objectContaining({
+        body: expect.stringContaining("\\\"type\\\": \\\"warning\\\""),
+      }));
+    });
+
+    it("send an info log", async () => {
+      await sendLog({ fileName: "testFile", functionName: "testFunction", type: "info", log: "Information" });
+
+      // then
+      expect(fetch).toHaveBeenCalledWith("http://example.net", expect.objectContaining({
+        body: expect.stringContaining("\\\"type\\\": \\\"info\\\""),
+      }));
+    });
+  });
+
+  describe("Send a log with missing or invalid URL", () => {
+    it("does not send a log if LOG_API_URL is missing", async () => {
+      // given
+      delete process.env.LOG_API_URL;
+
+      // when
+      await sendLog({ fileName: "testFile", functionName: "testFunction", type: "error", log: "Error occurred" });
+
+      // then
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not send a log if LOG_API_URL is invalid", async () => {
+      // given
+      process.env.LOG_API_URL = "";
+
+      // when
+      await sendLog({ fileName: "testFile", functionName: "testFunction", type: "error", log: "Error occurred" });
+
+      // then
+      expect(fetch).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalled;
+    });
+  });
+});

--- a/src/scripts/send-error-message-script.js
+++ b/src/scripts/send-error-message-script.js
@@ -1,0 +1,42 @@
+/*
+This file is used to send a notification on the discord server when an error occurs.
+ */
+
+async function sendLog({ fileName, functionName, type, log }) {
+  const redColor = 16711680;
+  // Create a message visible and readable
+  const message = {
+    type,
+    where: `${fileName} > ${functionName}`,
+    log,
+  };
+  // Log the message in the console for Vercel deployment
+  console.log(message);
+  const apiUrl = process.env.LOG_API_URL || null;
+  if (!apiUrl) {
+    return;
+  }
+  try {
+    let textMessage = "```json\n"+JSON.stringify(message, null, 2)+"\n```";
+    const request = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        embeds: [
+          {
+            title: "New message in log",
+            description: textMessage,
+            color: redColor,
+          },
+        ],
+      }),
+    };
+    await fetch(apiUrl, request);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export { sendLog };


### PR DESCRIPTION
This pull request introduces a new script to send error messages to a specified API and includes corresponding tests. The most important changes include the addition of the `sendLog` function and its comprehensive test coverage.

### New functionality:

* [`src/scripts/send-error-message-script.js`](diffhunk://#diff-6198ddaf77f7a737ccc95117bfe792d23a92d76a0d6cd1921a3a8cd9b8ee6390R1-R42): Added the `sendLog` function, which sends a log message to a specified API URL if the URL is defined. This function logs messages in the console and sends them as a JSON payload to the API.

### Test coverage:

* [`src/__tests__/scripts/send-error-message-script.spec.js`](diffhunk://#diff-b499a35efbc89039a40fad5dfd83783d58fa65633f38c4435ef0b03d0c1e4659R1-R57): Added tests for the `sendLog` function to ensure it correctly sends logs of different types (info, warning, error) and handles cases where the API URL is missing or invalid.