### PR TITLE
[TECH] Add a commit linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm test
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-vitest-globals": "^1.5.0",
         "eslint-plugin-vue": "^9.23.0",
+        "husky": "^9.1.7",
         "jsdom": "^24.1.0",
         "postcss": "^8.4.45",
         "prettier": "^3.2.5",
@@ -4840,6 +4841,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "bnote-settings",
   "version": "0.0.4",
-
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +13,8 @@
     "lint:fix": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
     "format": "prettier --write src/",
     "production": "sh script/release.sh",
-    "release": "standard-version"
+    "release": "standard-version",
+    "prepare": "husky"
   },
   "dependencies": {
     "@pinia/testing": "^0.1.7",
@@ -36,6 +36,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-vitest-globals": "^1.5.0",
     "eslint-plugin-vue": "^9.23.0",
+    "husky": "^9.1.7",
     "jsdom": "^24.1.0",
     "postcss": "^8.4.45",
     "prettier": "^3.2.5",


### PR DESCRIPTION
This pull request includes changes to add Husky for managing Git hooks and updates to the `package.json` file to include Husky as a dependency and configure it for pre-commit hooks.

### Husky integration:

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR1-R2): Added commands to run tests and linting before each commit.

### `package.json` updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R39): Added `husky` as a dependency.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R17): Added `prepare` script to set up Husky.