### PR TITLE
[BUGFIX] fix commit names and dependabot alert

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,16 @@ updates:
     interval: daily
     time: '00:00'
   open-pull-requests-limit: 3
+  - labels:
+      - dependencies
+      - npm
   reviewers:
     - theotime2005
   assignees:
     - theotime2005
   commit-message:
     prefix: bump
-    prefix-development: chore
+    prefix-development: bump
     include: scope
 # Fetch and update latest `github-actions` pkgs
 - package-ecosystem: github-actions
@@ -22,11 +25,14 @@ updates:
     interval: daily
     time: '00:00'
   open-pull-requests-limit: 2
+  labels:
+    - dependencies
+    - workflow
   reviewers:
     - theotime2005
   assignees:
     - theotime2005
   commit-message:
     prefix: bump
-    prefix-development: chore
+    prefix-development: bump
     include: scope

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-npm test
 npm run lint

--- a/package.json
+++ b/package.json
@@ -51,11 +51,7 @@
         "section": "Tests"
       },
       {
-        "type": "TECH",
-        "section": "Technical Tasks"
-      },
-      {
-        "type": "BUMP",
+        "type": "bump",
         "section": "Version Bumps"
       }
     ]


### PR DESCRIPTION
This pull request includes several changes to configuration files and scripts to improve consistency and streamline processes. The most important changes involve updating labels and commit message prefixes in the Dependabot configuration, modifying the pre-commit script, and adjusting the section types in the `package.json` file.

Changes to Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R19): Added `dependencies` and `npm` labels, and changed `prefix-development` from `chore` to `bump` for one update block.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R28-R37): Added `dependencies` and `workflow` labels, and changed `prefix-development` from `chore` to `bump` for another update block.

Changes to scripts:

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL1): Removed the `npm test` command from the pre-commit script.

Changes to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L54-R54): Changed the `type` from `BUMP` to `bump` in the version bumps section.