### PR TITLE
[FEATURE] Do not run tests if the "No deployment" label is present

### DIFF
--- a/.github/workflows/build-version.yml
+++ b/.github/workflows/build-version.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Check tests and eslint
+        run: |
+          npm test
+          npm run lint
+
       - name: Build new version
         # Use standard-version to generate a new version
         run: npm run release

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -9,7 +9,7 @@ jobs:
   vitest:
     runs-on: ubuntu-latest
 
-    if: github.event.pull_request.draft == false
+    if: "!contains(github.event.pull_request.labels.*.name, 'No deployment') && github.event.pull_request.draft == false"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes updates to the GitHub workflow configurations to enhance the testing and linting processes and to conditionally run certain jobs based on pull request labels.

Enhancements to testing and linting:

* [`.github/workflows/build-version.yml`](diffhunk://#diff-c8e0932e362c6cf2133d2797ec3edf7699d897d626a9f35f5e156ddc27636516R34-R38): Added steps to run tests and lint the code before building a new version.

Conditional job execution:

* [`.github/workflows/check-tests.yml`](diffhunk://#diff-e6ca5345641700b84db3333c2e2038a963319137c37cf92fa6c3e214ccb8ede3R10): Added a condition to skip the `vitest` job if the pull request contains the 'No deployment' label.