### PR TITLE
[BUGFIX] Correct the workflow to enable auto merge

### DIFF
--- a/.github/workflows/enable auto merge.yml
+++ b/.github/workflows/enable auto merge.yml
@@ -1,24 +1,50 @@
-name: enable auto merge
+name: Enable Auto Merge
 
 on:
   pull_request:
-    branches:
-      - main
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 jobs:
-  Enable-auto-merge:
+  enable_auto_merge:
     runs-on: ubuntu-latest
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge')
-
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge') && github.event.pull_request.draft == false
     steps:
-      - name: Enable auto merge
-        uses: actions/github-script@v3
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Enable Auto Merge
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
-            github.pulls.enableAutoMerge({
+            const pull_number = context.payload.pull_request.number;
+
+            // Récupérer l'ID du pull request (node_id)
+            const { repository } = await github.graphql(`
+              query($owner: String!, $repo: String!, $pull_number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pull_number) {
+                    id
+                  }
+                }
+              }
+            `, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
-              merge_method: 'merge'
-            })
+              pull_number
+            });
+
+            await github.graphql(`
+              mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: MERGE
+                }) {
+                  pullRequest {
+                    id
+                  }
+                }
+              }
+            `, {
+              pullRequestId: repository.pullRequest.id
+            });


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/enable auto merge.yml` file to enhance the auto-merge functionality for pull requests. The most important changes include updating the event types that trigger the workflow, modifying job and step names for consistency, and refining the auto-merge conditions.

Workflow improvements:

* Added `opened` and `reopened` event types to trigger the workflow on pull requests.
* Changed job and step names to use consistent casing (`enable_auto_merge`).
* Updated the condition to enable auto-merge only if the pull request is labeled "Ready to merge" and is not a draft.
* Added a step to checkout the repository before enabling auto-merge.
* Refined the script to use the `@actions/github` library for enabling auto-merge.