### PR TITLE
[BUGFIX] Add label ready to merge to Dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,13 @@ updates:
     labels:
       - dependencies
       - npm
+      - Ready to merge
     reviewers:
       - theotime2005
     assignees:
       - theotime2005
     commit-message:
-      prefix: bump
-      prefix-development: bump
+      prefix: [BUMP]
       include: scope
 
   # Fetch and update latest `github-actions` pkgs
@@ -29,11 +29,11 @@ updates:
     labels:
       - dependencies
       - workflow
+      - Ready to merge
     reviewers:
       - theotime2005
     assignees:
       - theotime2005
     commit-message:
-      prefix: bump
-      prefix-development: bump
+      prefix: [BUMP]
       include: scope

--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Validate PR title
         run: |
-          if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^\[(BUGFIX|FEATURE|TECH|deps-dev|DOC|BUMP)\]')" ]]; then
+          if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^\[(BUGFIX|FEATURE|TECH|DOCS|BUMP)\]')" ]]; then
             echo "Error: Pull request title must start with [BUGFIX], [TECH], [DOC], [BUMP] or [FEATURE]."
             exit 1
           fi


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yml` and `.github/workflows/PR Title Check.yml` files to improve the dependency management and pull request title validation process.

Improvements to dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13-R19): Added the "Ready to merge" label to the `updates:` section for both npm and `github-actions` packages. Updated the commit message prefix from "bump" to "[BUMP]". [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R32-R38)

Enhancements to pull request validation:

* [`.github/workflows/PR Title Check.yml`](diffhunk://#diff-e6d2be8389bd688a7879afcde237f873c599b6d1fe794a6a4352e4a428192e93L19-R19): Updated the PR title validation script to include "[DOCS]" as a valid prefix, replacing "[DOC]".