### PR TITLE
[BUGFIX] Fix Dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,9 @@ updates:
     reviewers:
       - theotime2005
     assignees:
-      - theotime2005
+      - dependabot
     commit-message:
-      prefix: [BUMP]
+      prefix: "[BUMP]"
       include: scope
 
   # Fetch and update latest `github-actions` pkgs
@@ -33,7 +33,7 @@ updates:
     reviewers:
       - theotime2005
     assignees:
-      - theotime2005
+      - dependabot
     commit-message:
-      prefix: [BUMP]
+      prefix: "[BUMP]"
       include: scope


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` file to update the assignee and commit message prefix for dependency updates.

Changes in `.github/dependabot.yml`:

* Updated the assignee from `theotime2005` to `dependabot` for dependency updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L17-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L36-R38)
* Modified the commit message prefix to include double quotes around `[BUMP]`. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L17-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L36-R38)