### PR TITLE
[BUGFIX] Put a translation string in the settings management page

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -162,7 +162,8 @@
             "downloadName": "Settings {date}",
             "how": "How does it work?",
             "explication": "You can either create a file directly from the site using the default template or load the file from a device.",
-            "question": "Do you really want to download the file?"
+            "question": "Do you really want to download the file?",
+            "resetQuestion": "Do you really want to erase the current configuration? You will need to import another file."
         }
     },
     "title": "B.note management",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -173,7 +173,8 @@
       "downloadName": "Préférence {date}",
       "how": "Comment ça marche?",
       "explication": "Vous pouvez soit créer un fichier directement à partir du site en utilisant le modèle par défaut, soit charger le fichier d'un appareil.",
-      "question": "Voulez-vous vraiment télécharger le fichier ?"
+      "question": "Voulez-vous vraiment télécharger le fichier ?",
+      "resetQuestion": "Voulez-vous vraiment effacer la configuration actuelle? Vous devrez importer un autre fichier."
     }
   },
   "faq": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -169,7 +169,8 @@
             "downloadName": "Preferenza {data}",
             "how": "Come funziona?",
             "explication": "È possibile creare un file direttamente dal sito utilizzando il modello predefinito o caricare il file da un dispositivo.",
-            "question": "Vuoi davvero scaricare il file?"
+            "question": "Vuoi davvero scaricare il file?",
+            "resetQuestion": "Vuoi davvero cancellare la configurazione corrente? Dovrai importare un altro file."
         }
     },
     "header": {

--- a/src/__tests__/acceptance/SettingsView.spec.js
+++ b/src/__tests__/acceptance/SettingsView.spec.js
@@ -6,24 +6,98 @@ describe("Acceptance | SettingsView", () => {
     wrapper = await render("/settings");
   });
 
-  it("should display the page when no file is uploaded", () => {
-    // when
-    const mainTitle = wrapper.find("h1").text();
-    const howTitle = wrapper.find("h2").text();
-    const fileSelector = wrapper.find("input[type='file']");
-    // then
-    expect(mainTitle).toContain("settings.page.title");
-    expect(howTitle).toContain("settings.page.how");
-    expect(fileSelector.exists()).toBe(true);
+  suite("when no file is uploaded", () => {
+    it("should display the default page", () => {
+      // when
+      const mainTitle = wrapper.find("h1").text();
+      const howTitle = wrapper.find("h2").text();
+      const fileSelector = wrapper.find("input[type='file']");
+      // then
+      expect(mainTitle).toContain("settings.page.title");
+      expect(howTitle).toContain("settings.page.how");
+      expect(fileSelector.exists()).toBe(true);
+    });
+
+    it("should display the default model when clicking the default button", async function () {
+      // when
+      const defaultButton = wrapper.findAll("button").find((button) => button.text() === "settings.page.create");
+
+      // then
+      await defaultButton.trigger("click");
+      const fileTitle = wrapper.find("h2").text();
+      expect(fileTitle).toBe("settings.page.defaultName");
+    });
   });
 
-  it("should display the default model when clicking the default button", async function () {
-    // when
-    const defaultButton = wrapper.findAll("button").find((button) => button.text() === "settings.page.create");
+  suite("when a file is uploaded", () => {
+    beforeEach(async function () {
+      const defaultButton = wrapper.findAll("button").find((button) => button.text() === "settings.page.create");
+      await defaultButton.trigger("click");
+    });
 
-    // then
-    await defaultButton.trigger("click");
-    const fileTitle = wrapper.find("h2").text();
-    expect(fileTitle).toBe("settings.page.defaultName");
+    describe("test the dialogs box", () => {
+      beforeEach(function () {
+        vi.spyOn(window, "confirm").mockReturnValue(true);
+      });
+
+      afterEach(function() {
+        vi.restoreAllMocks();
+      });
+
+      it("should displays dialog when you want open another file", async () => {
+        // given
+        const resetButton = wrapper.findAll("button").find((button) => button.text() === "settings.page.openOther");
+
+        // when
+        await resetButton.trigger("click");
+
+        // then
+        expect(window.confirm).toHaveBeenCalledWith("settings.page.resetQuestion");
+        expect(wrapper.find("h2").text()).toBe("settings.page.how");
+      });
+
+      it("should displays confirmation when click to download button", async () => {
+        // given
+        global.URL.createObjectURL = vi.fn(() => "blob:url");
+        global.URL.revokeObjectURL = vi.fn();
+        const downloadButton = wrapper.findAll("button").find((button) => button.text() === "settings.page.download");
+
+        // when
+        await downloadButton.trigger("submit");
+
+        // then
+        expect(window.confirm).toHaveBeenCalledWith("settings.page.question");
+        expect(global.URL.createObjectURL).toHaveBeenCalled();
+        expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+      });
+    });
+
+    describe("tests button to open or close sections", () => {
+      it("should open section when clicks on the button", async () => {
+        // given
+        const button = wrapper.findAll("button").find((buton) => buton.text() === "settings.page.show");
+
+        // when
+        await button.trigger("click");
+
+        // then
+        const hideButton = wrapper.findAll("button").find((buton) => buton.text() === "settings.page.hide");
+        expect(hideButton.exists()).toBe(true);
+      });
+
+      it("should close section when clicks on the button", async () => {
+        // given
+        const button = wrapper.findAll("button").find((buton) => buton.text() === "settings.page.show");
+        await button.trigger("click");
+
+        // when
+        const hideButton = wrapper.findAll("button").find((buton) => buton.text() === "settings.page.hide");
+        await hideButton.trigger("click");
+
+        // then
+        const showButton = wrapper.findAll("button").find((buton) => buton.text() === "settings.page.show");
+        expect(showButton.exists()).toBe(true);
+      });
+    });
   });
 });

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -39,7 +39,7 @@ export default {
     },
     clean_data() {
       const confirm = window.confirm(
-        "Voulez-vous vraiment effacer la configuration actuelle? Vous devrez importer un autre fichier.",
+        this.$t("settings.page.resetQuestion"),
       );
       if (confirm) {
         this.settingsData = {};


### PR DESCRIPTION
This pull request includes updates to localization files and improvements to the `SettingsView` component and its tests. The most important changes include adding a new confirmation message for resetting configurations and enhancing the test coverage for the `SettingsView` component.

Localization updates:

* [`locales/en.json`](diffhunk://#diff-c9218bed23f0aeb93d7e1a7d5f6e1345fae20f4b8692b27fb97fd0f37b3d26d7L165-R166): Added a new confirmation message for resetting configurations.
* [`locales/fr.json`](diffhunk://#diff-86d23a5be9d54f3c756b91e0d6412ac8bbbb232600ab2ee5554ca46079b4f1e6L176-R177): Added a new confirmation message for resetting configurations.
* [`locales/it.json`](diffhunk://#diff-857654eba54a2149d43ab51b00c1daf863edc718308286e32a96cad8dc79342cL172-R173): Added a new confirmation message for resetting configurations.

Test enhancements:

* [`src/__tests__/acceptance/SettingsView.spec.js`](diffhunk://#diff-405bbe0c4c42660463269f3304a5b1db0114c7df30cb809387a83781a841a88fL9-R10): Refactored existing tests and added new test cases to cover scenarios when a file is uploaded, including dialogs and section toggling. [[1]](diffhunk://#diff-405bbe0c4c42660463269f3304a5b1db0114c7df30cb809387a83781a841a88fL9-R10) [[2]](diffhunk://#diff-405bbe0c4c42660463269f3304a5b1db0114c7df30cb809387a83781a841a88fR31-R103)

Component update:

* [`src/views/SettingsView.vue`](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6L42-R42): Updated the `clean_data` method to use the new localization key for the reset confirmation message.