### PR TITLE
[BUGFIX] Grant write access to a pull request

### DIFF
--- a/.github/workflows/enable auto merge.yml
+++ b/.github/workflows/enable auto merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   enable_auto_merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/enable auto merge.yml` file. The change adds permissions for `pull-requests` and `contents` to the workflow configuration.

* [`.github/workflows/enable auto merge.yml`](diffhunk://#diff-39a04bab1c94543645918dfaeae11f004c72e1c6546ac2ad9a1d000aba25d5a9R7-R10): Added `permissions` section with `pull-requests: write` and `contents: read` to the workflow configuration.