### PR TITLE
[TECH] Use a special token for Dependabot

### DIFF
--- a/.github/workflows/enable auto merge.yml
+++ b/.github/workflows/enable auto merge.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Enable Auto Merge
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ github.actor == 'dependabot[bot]' && secrets.DEPENDABOT_TOKEN || secrets.GH_TOKEN }}
           script: |
             const pull_number = context.payload.pull_request.number;
 


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/enable auto merge.yml` file to enhance the security of the GitHub Actions workflow by using different tokens based on the actor.

Security enhancement:

* [`.github/workflows/enable auto merge.yml`](diffhunk://#diff-39a04bab1c94543645918dfaeae11f004c72e1c6546ac2ad9a1d000aba25d5a9L22-R22): Modified the `github-token` to use `secrets.DEPENDABOT_TOKEN` if the actor is `dependabot[bot]`, otherwise it uses `secrets.GH_TOKEN`.