### PR TITLE
[TECH] Add an input in the workflow to generate a version

### DIFF
--- a/.github/workflows/build-version.yml
+++ b/.github/workflows/build-version.yml
@@ -5,6 +5,11 @@ name: "Build version"
 
 on:
   workflow_dispatch:
+    input:
+      release_type:
+        description: "The type of release to generate"
+        required: true
+        default: "patch"
 
 permissions:
   contents: write
@@ -14,6 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check if input is valid
+        run: |
+          if [[ "${{ github.event.inputs.release_type }}" != "major" && "${{ github.event.inputs.release_type }}" != "minor" && "${{ github.event.inputs.release_type }}" != "patch" ]]; then
+            echo "Invalid release type. Please use 'major', 'minor' or 'patch'."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -38,7 +50,7 @@ jobs:
 
       - name: Build new version
         # Use standard-version to generate a new version
-        run: npm run release
+        run: npm run release -- --release-as ${{ github.event.inputs.release_type }}
 
       - name: Push new version
         run: git push --follow-tags origin main


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build-version.yml` file to enhance the build version workflow by adding input validation and allowing different types of releases. The most important changes are summarized below:

Enhancements to build version workflow:

* Added `release_type` input to allow specifying the type of release to generate.
* Included a validation step to ensure the `release_type` input is either 'major', 'minor', or 'patch'.
* Modified the build step to use the specified `release_type` for generating the new version.