### PR TITLE
[BUGFIX] Add a s to inputs

### DIFF
--- a/.github/workflows/build-version.yml
+++ b/.github/workflows/build-version.yml
@@ -5,7 +5,7 @@ name: "Build version"
 
 on:
   workflow_dispatch:
-    input:
+    inputs:
       release_type:
         description: "The type of release to generate"
         required: true


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-version.yml` file. The change corrects a typo in the `workflow_dispatch` event configuration by renaming `input` to `inputs`.