### PR TITLE
[FEATURE] Keep the data on the settings page and display a warning if the user wants to leave the page without having saved

### DIFF
--- a/src/__tests__/components/UploadFileComponent.spec.js
+++ b/src/__tests__/components/UploadFileComponent.spec.js
@@ -59,7 +59,7 @@ describe("UploadFileComponent.vue", () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     // then
-    expect(mockLoadSettings).toHaveBeenCalledWith(JSON.parse(fileContent));
+    expect(mockLoadSettings).toHaveBeenCalledWith(JSON.parse(fileContent), wrapper.vm.fileInput.name.split(".")[0]);
     expect(wrapper.emitted("file-uploaded")).toBeTruthy();
   });
 });

--- a/src/__tests__/stores/settingsStore.spec.js
+++ b/src/__tests__/stores/settingsStore.spec.js
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from "pinia";
 import { useSettingsStore } from "@/stores/settingsStore";
 
 describe("Settings Store", () => {
+  const fileName = "settings";
   beforeEach(() => {
     setActivePinia(createPinia());
   });
@@ -13,16 +14,17 @@ describe("Settings Store", () => {
     const settingsObject = { general: { theme: "dark" } };
 
     // when
-    store.loadSettings(settingsObject);
+    store.loadSettings(settingsObject, fileName);
 
     // then
     expect(store.settings).toEqual(settingsObject);
+    expect(store.fileName).toBe(fileName);
   });
 
   it("updates a setting correctly", () => {
     // given
     const store = useSettingsStore();
-    store.loadSettings({ general: { theme: "dark" } });
+    store.loadSettings({ general: { theme: "dark" } }, fileName);
 
     // when
     store.updateSetting("general", "theme", "light");
@@ -34,7 +36,7 @@ describe("Settings Store", () => {
   it("gets a setting correctly", () => {
     // given
     const store = useSettingsStore();
-    store.loadSettings({ general: { theme: "dark" } });
+    store.loadSettings({ general: { theme: "dark" } }, fileName);
 
     // when
     const theme = store.getSetting("general", "theme");
@@ -47,7 +49,7 @@ describe("Settings Store", () => {
     // given
     const store = useSettingsStore();
     const settingsObject = { general: { theme: "dark" } };
-    store.loadSettings(settingsObject);
+    store.loadSettings(settingsObject, fileName);
 
     // when
     const allSettings = store.getAllSettings;
@@ -60,7 +62,7 @@ describe("Settings Store", () => {
     // given
     const settingsObject = { general: { theme: "dark" } };
     const store = useSettingsStore();
-    store.loadSettings(settingsObject);
+    store.loadSettings(settingsObject, fileName);
 
     // when
     store.updateSetting("nonExistentSection", "key", "value");
@@ -73,7 +75,7 @@ describe("Settings Store", () => {
     // given
     const settingsObject = { general: { theme: "dark" } };
     const store = useSettingsStore();
-    store.loadSettings(settingsObject);
+    store.loadSettings(settingsObject, fileName);
 
     // when
     const value = store.getSetting("nonExistentSection", "key");

--- a/src/components/UploadFileComponent.vue
+++ b/src/components/UploadFileComponent.vue
@@ -24,7 +24,7 @@ export default {
         file.readAsText(this.fileInput);
 
         file.onloadend = (e) => {
-          useSettingsStore().loadSettings(JSON.parse(e.target.result));
+          useSettingsStore().loadSettings(JSON.parse(e.target.result), this.fileInput.name.split(".")[0]);
 
           this.$emit("file-uploaded");
         };

--- a/src/stores/settingsStore.js
+++ b/src/stores/settingsStore.js
@@ -3,10 +3,12 @@ import { defineStore } from "pinia";
 export const useSettingsStore = defineStore("settingsStore", {
   state: () => ({
     settings: {},
+    fileName: "",
   }),
   actions: {
-    loadSettings (settingsObject) {
+    loadSettings (settingsObject, fileName) {
       this.settings = settingsObject;
+      this.fileName = fileName;
     },
     updateSetting(section, key, value) {
       if (!this.settings[section]) {
@@ -16,6 +18,7 @@ export const useSettingsStore = defineStore("settingsStore", {
     },
     removeAll() {
       this.settings = {};
+      this.fileName = "";
     },
   },
   getters: {
@@ -28,7 +31,13 @@ export const useSettingsStore = defineStore("settingsStore", {
       return state.settings[section][key];
     },
     getAllSettings: (state) => {
+      if (Object.keys(state.settings).length === 0) {
+        return null;
+      }
       return state.settings;
+    },
+    getFileName() {
+      return this.fileName || null;
     },
   },
 });

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -37,6 +37,7 @@ export default {
       if (confirm) {
         this.fileIsImported = false;
         useSettingsStore().removeAll();
+        window.removeEventListener("beforeunload", this.handleBeforeReload);
       }
     },
     complete_empty_values() {
@@ -64,10 +65,12 @@ export default {
       this.file_name = this.$t("settings.page.defaultName");
       useSettingsStore().loadSettings(data, this.file_name);
       this.fileIsImported = true;
+      window.addEventListener("beforeunload", this.handleBeforeReload);
     },
     showFile() {
       this.file_name = useSettingsStore().getFileName;
       this.fileIsImported = true;
+      window.addEventListener("beforeunload", this.handleBeforeReload);
     },
     togle_menu(key) {
       this.display_menu[key] = !this.display_menu[key];
@@ -101,6 +104,10 @@ export default {
         this.closeAllMenus();
       }
     },
+    handleBeforeReload(event) {
+      event.preventDefault();
+      event.returnValue = "";
+    },
   },
   mounted() {
     // Add listener to the "Escape" key
@@ -109,11 +116,13 @@ export default {
     if (useSettingsStore().getAllSettings) {
       this.file_name = useSettingsStore().getFileName;
       this.fileIsImported = true;
+      window.addEventListener("beforeunload", this.handleBeforeReload);
     }
   },
   beforeUnmount() {
     // Remove listener to the "Escape" key
     window.removeEventListener("keydown", this.handleKeyPress);
+    window.removeEventListener("beforeunload", this.handleBeforeReload);
   },
 };
 </script>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -61,12 +61,12 @@ export default {
           data[section][setting] = this.all_settings[section][setting].default;
         }
       }
-      useSettingsStore().loadSettings(data);
       this.file_name = this.$t("settings.page.defaultName");
+      useSettingsStore().loadSettings(data, this.file_name);
       this.fileIsImported = true;
     },
     showFile() {
-      this.file_name = this.$refs.upload.file_name;
+      this.file_name = useSettingsStore().getFileName;
       this.fileIsImported = true;
     },
     togle_menu(key) {
@@ -105,6 +105,11 @@ export default {
   mounted() {
     // Add listener to the "Escape" key
     window.addEventListener("keydown", this.handleKeyPress);
+    // Check if store has content
+    if (useSettingsStore().getAllSettings) {
+      this.file_name = useSettingsStore().getFileName;
+      this.fileIsImported = true;
+    }
   },
   beforeUnmount() {
     // Remove listener to the "Escape" key


### PR DESCRIPTION
This pull request includes updates to the `settingsStore` to track the file name associated with the settings and ensures proper event handling for the window before unload event. The most important changes include modifications to the store's state and actions, updates to the test cases, and adjustments to the `SettingsView` component.

### Store Updates:
* [`src/stores/settingsStore.js`](diffhunk://#diff-62cd24f59f77bffd672d5c4b07f77efb90866b3d9b90da00816c14bab1b1858aR6-R11): Added `fileName` to the state and modified the `loadSettings` and `removeAll` actions to handle the `fileName`. Added a `getFileName` getter. [[1]](diffhunk://#diff-62cd24f59f77bffd672d5c4b07f77efb90866b3d9b90da00816c14bab1b1858aR6-R11) [[2]](diffhunk://#diff-62cd24f59f77bffd672d5c4b07f77efb90866b3d9b90da00816c14bab1b1858aR21) [[3]](diffhunk://#diff-62cd24f59f77bffd672d5c4b07f77efb90866b3d9b90da00816c14bab1b1858aR34-R41)

### Test Case Updates:
* [`src/__tests__/stores/settingsStore.spec.js`](diffhunk://#diff-64d3aec5140a6d0d71c8e9b16331af2c956dadc887ee920f4f875ca6fc0fba99R6): Updated test cases to include the `fileName` parameter in `loadSettings` calls and added assertions for `fileName`. [[1]](diffhunk://#diff-64d3aec5140a6d0d71c8e9b16331af2c956dadc887ee920f4f875ca6fc0fba99R6) [[2]](diffhunk://#diff-64d3aec5140a6d0d71c8e9b16331af2c956dadc887ee920f4f875ca6fc0fba99L16-R27) [[3]](diffhunk://#diff-64d3aec5140a6d0d71c8e9b16331af2c956dadc887ee920f4f875ca6fc0fba99L37-R39) [[4]](diffhunk://#diff-64d3aec5140a6d0d71c8e9b16331af2c956dadc887ee920f4f875ca6fc0fba99L50-R52) [[5]](diffhunk://#diff-64d3aec5140a6d0d71c8e9b16331af2c956dadc887ee920f4f875ca6fc0fba99L63-R65) [[6]](diffhunk://#diff-64d3aec5140a6d0d71c8e9b16331af2c956dadc887ee920f4f875ca6fc0fba99L76-R78)

### Component Updates:
* [`src/views/SettingsView.vue`](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6R40): Updated methods to handle the `fileName` and added event listeners for the window before unload event to prevent accidental data loss. [[1]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6R40) [[2]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6L64-R73) [[3]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6R107-R125)