### PR TITLE
[TECH] Add workflow to comment pull requests

### DIFF
--- a/.github/workflows/comment-close-pull-request.yml
+++ b/.github/workflows/comment-close-pull-request.yml
@@ -1,0 +1,20 @@
+# This workflow comments on a pull request when it’s merged
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  comment-close-pull-request:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Comment pull request
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} -b "This pull request has been merged and closed. Thank you for your contribution! 🎉
+            Your work will be published in the feature deployment."
+        env:
+          GH_TOKEN: ${{secrets.GH_TOKEN}}

--- a/.github/workflows/comment-open-pull-request.yml
+++ b/.github/workflows/comment-open-pull-request.yml
@@ -1,0 +1,23 @@
+# This workflow comments on a pull request when it is opened.
+name: Comment Open Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  comment-open-pull-request:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v4
+      - name: Comment pull request
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "Hello,
+            Thank you for your contribution to this project. In order for your pull request to be in merging condition, make sure to respect the [contribution guide](https://github.com/theotime2005/bnote-settings/blob/main/Contribution%20guide.md).
+            Once your pull request is validated, the ready to merge label will be added to merge it."
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This pull request introduces two new GitHub workflows to automate commenting on pull requests when they are opened and closed. These workflows aim to improve communication with contributors by providing timely feedback and instructions.

New GitHub workflows:

* [`.github/workflows/comment-close-pull-request.yml`](diffhunk://#diff-a0c6b80b0c8ddbec312a22c33b55ec4359cab6e9891e9c519387d23c99a1e0f6R1-R15): Adds a workflow to comment on a pull request when it is merged, thanking the contributor and informing them about the feature deployment.
* [`.github/workflows/comment-open-pull-request.yaml`](diffhunk://#diff-49d44f98e2ee5868e602e6e156d6a2b1240ed63947f022457ee9ae36f5e6d2fbR1-R20): Adds a workflow to comment on a pull request when it is opened, guiding the contributor to follow the contribution guide and informing them about the merging process.