### PR TITLE
[BUGFIX] Remove unnecessary sections of style and stylize the button at the top of the page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@ const focusMain = () => {
 </script>
 
 <template>
-  <button @click="focusMain">{{$t('skip-content')}}</button>
+  <button @click="focusMain" class="sr-only">{{$t('skip-content')}}</button>
   <NavBarComponent />
   <main class="flex flex-col grow overflow-y-scroll" ref="mainRef" tabindex="-1">
     <RouterView />

--- a/src/components/FooterComponent.vue
+++ b/src/components/FooterComponent.vue
@@ -25,7 +25,3 @@ export default {
     <p>{{$t('footer.version', {version: version})}}</p>
   </footer>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/LanguageComponent.vue
+++ b/src/components/LanguageComponent.vue
@@ -28,5 +28,3 @@ export default {
     </select>
   </div>
 </template>
-
-<style scoped></style>

--- a/src/components/SettingComponent.vue
+++ b/src/components/SettingComponent.vue
@@ -109,7 +109,3 @@ export default {
   </div>
   <br />
 </template>
-
-<style scoped>
-/* Styles personnalisés ici */
-</style>

--- a/src/components/UploadFileComponent.vue
+++ b/src/components/UploadFileComponent.vue
@@ -46,5 +46,3 @@ export default {
     </form>
   </div>
 </template>
-
-<style scoped></style>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -29,7 +29,3 @@ export default {
   <a :href="links.github.issues.report" target="_blank">{{$t('about.bug_report')}}</a>
 
 </template>
-
-<style scoped>
-
-</style>

--- a/src/views/DownloadPageView.vue
+++ b/src/views/DownloadPageView.vue
@@ -76,7 +76,3 @@ export default {
         </div>
   </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/views/FaqView.vue
+++ b/src/views/FaqView.vue
@@ -70,7 +70,3 @@ export default {
     <p v-else class="text-center text-gray-500">{{ $t('faq.nofaq') }}</p>
   </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -18,7 +18,3 @@ export default {
     </div>
   </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -202,5 +202,3 @@ export default {
 
   </div>
 </template>
-
-<style scoped></style>


### PR DESCRIPTION
This pull request includes changes to improve accessibility and clean up unused styles in the codebase. The most important changes include adding a screen reader-only class to the skip content button and removing unnecessary scoped styles from several components and views.

Accessibility improvement:

* [`src/App.vue`](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L18-R18): Added a `class="sr-only"` to the skip content button to make it more accessible for screen readers.

Code cleanup:

* [`src/components/FooterComponent.vue`](diffhunk://#diff-7490b18034c0e87a348ce68c97884563c04d5fbe2ff5f42a85dc927ff0ce5f94L28-L31): Removed unused scoped styles.
* [`src/components/LanguageComponent.vue`](diffhunk://#diff-e4549888235201835af39686be6a12f253ad3cf5a47d20d5040a6e2d90779e43L31-L32): Removed unused scoped styles.
* [`src/components/SettingComponent.vue`](diffhunk://#diff-4b510c76d34984739ba35e177e172004533c9000a381ecd3963ab3b20b28b851L112-L115): Removed unused scoped styles.
* [`src/components/UploadFileComponent.vue`](diffhunk://#diff-bd9f944f416afa6444a3bf9b8f36a35b9ddb877861404829691e888487c57af5L49-L50): Removed unused scoped styles.