### PR TITLE
[TECH] Remove unused scopes in standard version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,46 +16,6 @@
     "release": "standard-version",
     "prepare": "husky"
   },
-  "standard-version": {
-    "types": [
-      {
-        "type": "feat",
-        "section": "Features"
-      },
-      {
-        "type": "fix",
-        "section": "Bug Fixes"
-      },
-      {
-        "type": "chore",
-        "section": "Chores"
-      },
-      {
-        "type": "docs",
-        "section": "Documentation"
-      },
-      {
-        "type": "style",
-        "section": "Styles"
-      },
-      {
-        "type": "refactor",
-        "section": "Refactors"
-      },
-      {
-        "type": "perf",
-        "section": "Performance"
-      },
-      {
-        "type": "test",
-        "section": "Tests"
-      },
-      {
-        "type": "bump",
-        "section": "Version Bumps"
-      }
-    ]
-  },
   "dependencies": {
     "@pinia/testing": "^1.0.0",
     "@tailwindcss/vite": "^4.0.6",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change removes the custom configuration for `standard-version` which defined sections for different commit types.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19-L58): Removed the `standard-version` configuration that specified sections for commit types like "Features", "Bug Fixes", "Chores", etc.