### PR TITLE
[BUGFIX] Fermer la barre de navigation lorsqu'on clique dessus et amener le curseur sur le contenu de la page lorsqu'on clique sur un lien

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,7 @@ const focusMain = () => {
 
 <template>
   <button @click="focusMain" class="sr-only">{{$t('skip-content')}}</button>
-  <NavBarComponent />
+  <NavBarComponent @move-cursor="focusMain" />
   <main class="flex flex-col grow overflow-y-scroll" ref="mainRef" tabindex="-1">
     <RouterView />
   </main>

--- a/src/components/NavBarComponent.vue
+++ b/src/components/NavBarComponent.vue
@@ -17,10 +17,17 @@ export default {
     handleResize() {
       if (window.innerWidth > 768) {
         this.navBarIsVisible = true;
+        this.buttonIsVisible = false;
       } else {
         this.navBarIsVisible = false;
         this.buttonIsVisible = true;
       }
+    },
+    goto() {
+      if (this.buttonIsVisible) {
+        this.toggleNavBar();
+      }
+      this.$emit("move-cursor");
     },
   },
   mounted() {
@@ -47,6 +54,7 @@ export default {
           v-for="route in routes"
           :key="route.name"
           :to="route.path"
+          @click="goto"
         >{{ $t(`${route.name}.title`) }}
         </RouterLink>
       </menu>


### PR DESCRIPTION
This pull request includes changes to the `src/App.vue` and `src/components/NavBarComponent.vue` files to improve navigation accessibility and behavior. The most important changes include adding an event listener for cursor movement and updating the visibility of navigation elements based on screen size.

Improvements to navigation accessibility:

* [`src/App.vue`](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L19-R19): Added the `@move-cursor` event listener to the `NavBarComponent` to focus the main content when navigation occurs.

Updates to navigation behavior:

* [`src/components/NavBarComponent.vue`](diffhunk://#diff-a7a38de5ec74651b5cfb7131c9e7be7823db58565d6f459a9dd7ea2903c022ebR20-R31): Modified the `handleResize` method to update the visibility of a button based on screen size.
* [`src/components/NavBarComponent.vue`](diffhunk://#diff-a7a38de5ec74651b5cfb7131c9e7be7823db58565d6f459a9dd7ea2903c022ebR20-R31): Added the `goto` method to handle cursor movement and emit the `move-cursor` event when a navigation link is clicked.
* [`src/components/NavBarComponent.vue`](diffhunk://#diff-a7a38de5ec74651b5cfb7131c9e7be7823db58565d6f459a9dd7ea2903c022ebR57): Added the `@click="goto"` event listener to navigation links to trigger the `goto` method.