### PR TITLE
[TECH] Add a feature toggle for switching to api composition

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -11,3 +11,8 @@
 # Accept: development, production
 # default value is development
 # VUE_APP_ENVIRONMENT=
+
+# Type boolean
+# Use components with composition api
+# default: false
+# FT_ENABLE_COMPOSITION_API=false


### PR DESCRIPTION
This pull request includes a small change to the `sample.env` file. The change adds a new configuration option to enable or disable the use of components with the composition API.

* [`sample.env`](diffhunk://#diff-b80385df109d2e96812772e7905b6d846a851623b7261d35480bdb4e83a009d0R14-R18): Added a new boolean configuration option `FT_ENABLE_COMPOSITION_API` with a default value of `false`.