### PR TITLE
[FEATURE] Add a cookie to save the language on the site

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@pinia/testing": "^1.0.0",
     "@tailwindcss/vite": "^4.0.6",
     "@vue/compiler-sfc": "^3.5.13",
+    "js-cookie": "^3.0.5",
     "pinia": "^3.0.1",
     "tailwindcss": "^4.0.6",
     "translatte": "^3.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,11 @@
 <script setup>
-import { ref } from "vue";
+import { onBeforeMount, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { RouterView } from "vue-router";
 
 import FooterComponent from "@/components/FooterComponent.vue";
 import NavBarComponent from "@/components/NavBarComponent.vue";
+import { useLocaleCookie } from "@/scripts/useLocaleCookie.js";
 
 const mainRef = ref(null);
 
@@ -12,6 +14,14 @@ const focusMain = () => {
     mainRef.value.focus();
   }
 };
+
+onBeforeMount(function() {
+  // set locale from cookie
+  const localeCookie = useLocaleCookie.getLocaleCookie();
+  if (localeCookie) {
+    useI18n().locale.value = localeCookie;
+  }
+});
 </script>
 
 <template>

--- a/src/__tests__/scripts/useLocaleCookie.spec.js
+++ b/src/__tests__/scripts/useLocaleCookie.spec.js
@@ -1,0 +1,46 @@
+import cookies from "js-cookie";
+
+import { useLocaleCookie } from "@/scripts/useLocaleCookie";
+
+describe("useLocaleCookie", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets the locale cookie with the correct value and expiration", () => {
+    // given
+    const locale = "en";
+    vi.spyOn(cookies, "set");
+
+    // when
+    useLocaleCookie.setLocaleCookie(locale);
+
+    // then
+    expect(cookies.set).toHaveBeenCalledWith("locale", locale, { expires: 365 });
+  });
+
+  it("gets the locale cookie value", () => {
+    // given
+    const locale = "en";
+    cookies.get = vi.fn().mockReturnValue(locale);
+
+    // when
+    const result = useLocaleCookie.getLocaleCookie();
+
+    // then
+    expect(result).toBe(locale);
+    expect(cookies.get).toHaveBeenCalledWith("locale");
+  });
+
+  it("returns undefined if the locale cookie is not set", () => {
+    // given
+    cookies.get = vi.fn().mockReturnValue(undefined);
+
+    // when
+    const result = useLocaleCookie.getLocaleCookie();
+
+    // then
+    expect(result).toBeUndefined();
+    expect(cookies.get).toHaveBeenCalledWith("locale");
+  });
+});

--- a/src/components/LanguageComponent.vue
+++ b/src/components/LanguageComponent.vue
@@ -1,4 +1,5 @@
 <script>
+import { useLocaleCookie } from "@/scripts/useLocaleCookie.js";
 export default {
   name: "LanguageComponent",
   data() {
@@ -10,6 +11,7 @@ export default {
     changeLanguage() {
       this.$i18n.locale = this.current_language;
       document.documentElement.lang = this.current_language;
+      useLocaleCookie.setLocaleCookie(this.current_language);
     },
   },
   mounted() {

--- a/src/scripts/useLocaleCookie.js
+++ b/src/scripts/useLocaleCookie.js
@@ -1,0 +1,11 @@
+import cookies from "js-cookie";
+
+export const useLocaleCookie = {
+  setLocaleCookie(locale) {
+    cookies.set("locale", locale, { expires: 365 });
+  },
+
+  getLocaleCookie() {
+    return cookies.get("locale");
+  },
+};


### PR DESCRIPTION
This pull request introduces the use of cookies to manage locale settings and updates several components and tests accordingly. The most important changes include adding a new dependency, updating the main application component, creating a new utility script, and modifying tests and other components to use this new functionality.

### New Dependency:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R23): Added `js-cookie` dependency to manage cookies.

### Main Application Updates:
* [`src/App.vue`](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L2-R8): Imported `useI18n` and `useLocaleCookie`, and added a function to set the locale from a cookie on mount. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L2-R8) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R17-R24)

### New Utility Script:
* [`src/scripts/useLocaleCookie.js`](diffhunk://#diff-10616058f7dae80babc68c2d2ea609c617d92e44a7c134b955f2627a5acf27a6R1-R11): Created a new utility script to set and get locale cookies using `js-cookie`.

### Component Updates:
* [`src/components/LanguageComponent.vue`](diffhunk://#diff-e4549888235201835af39686be6a12f253ad3cf5a47d20d5040a6e2d90779e43R2): Updated the language change method to set the locale cookie when the language is changed. [[1]](diffhunk://#diff-e4549888235201835af39686be6a12f253ad3cf5a47d20d5040a6e2d90779e43R2) [[2]](diffhunk://#diff-e4549888235201835af39686be6a12f253ad3cf5a47d20d5040a6e2d90779e43R14)

### Test Updates:
* [`src/__tests__/scripts/useLocaleCookie.spec.js`](diffhunk://#diff-59dba3dff0a593c0b17474add4357dbd97965284829c70250e64660316da0b2bR1-R46): Added tests for the new `useLocaleCookie` utility to ensure correct behavior for setting and getting locale cookies.