### PR TITLE
[TECH] Do not comment on the pr that I open myself

### DIFF
--- a/.github/workflows/comment-close-pull-request.yml
+++ b/.github/workflows/comment-close-pull-request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   comment-close-pull-request:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.merged == true && github.actor != 'dependabot[bot]' && github.actor != 'theotime2005'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/comment-open-pull-request.yml
+++ b/.github/workflows/comment-open-pull-request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   comment-open-pull-request:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'theotime2005'
     steps:
       - name: checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to exclude a specific user from triggering certain actions.

* [`.github/workflows/comment-close-pull-request.yml`](diffhunk://#diff-a0c6b80b0c8ddbec312a22c33b55ec4359cab6e9891e9c519387d23c99a1e0f6L10-R10): Updated the condition to exclude the user `theotime2005` from triggering the workflow when a pull request is merged.
* [`.github/workflows/comment-open-pull-request.yml`](diffhunk://#diff-4f338c006b2da7041ada410ad84381592d21855a7bde38020d0dce6905dc3f62L13-R13): Updated the condition to exclude the user `theotime2005` from triggering the workflow when a pull request is opened.