### PR TITLE
[BUGFIX] Fix the workflow for version build

### DIFF
--- a/.github/workflows/build-version.yml
+++ b/.github/workflows/build-version.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup node js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-version.yml` file. The change sets the `fetch-depth` parameter to `0` in the `actions/checkout@v4` step to ensure the full repository history is fetched.