### PR TITLE
[TECH] Refactor the ci and the auto merge action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,9 +8,7 @@ on:
       - labeled
       - unlabeled
       - synchronize
-  check_suite:
-    types:
-      - completed
+      - ready_for_review
 
 permissions:
   pull-requests: write

--- a/package.json
+++ b/package.json
@@ -18,40 +18,36 @@
   "standard-version": {
     "types": [
       {
-        "type": "feat",
-        "section": "Features"
+        "type": "[FEATURE]",
+        "section": "🚀 New features"
       },
       {
-        "type": "fix",
-        "section": "Bug Fixes"
+        "type": "[BUGFIX]",
+        "section": "🐛 Bug fixes"
       },
       {
-        "type": "chore",
-        "section": "Chores"
+        "type": "[DOCS]",
+        "section": "📚 Documentation"
       },
       {
-        "type": "docs",
-        "section": "Documentation"
+        "type": "[Styles]",
+        "section": "💅 Styles"
       },
       {
-        "type": "style",
-        "section": "Styles"
+        "type": "[REFACTOR]",
+        "section": "🔨 Code Refactoring"
       },
       {
-        "type": "refactor",
-        "section": "Refactors"
+        "type": "[PERF]",
+        "section": "⚡ Performance Improvements"
       },
       {
-        "type": "perf",
-        "section": "Performance"
+        "type": "[TESTs]",
+        "section": "🧪 Tests"
       },
       {
-        "type": "test",
-        "section": "Tests"
-      },
-      {
-        "type": "bump",
-        "section": "Version Bumps"
+        "type": "[BUMP]",
+        "section": "🔖 Version Bump"
       }
     ]
   },


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration and the `package.json` file. The most important changes involve updating the workflow triggers and modifying the versioning configuration to use more descriptive labels.

Workflow configuration changes:

* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L11-R11): Replaced `check_suite` trigger with `ready_for_review` trigger to streamline the workflow events.

Versioning configuration changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R50): Updated the `standard-version` configuration to use more descriptive labels for different types of changes, such as `[FEATURE]`, `[BUGFIX]`, and `[DOCS]`.