### PR TITLE
[TECH] Restore the old configuration of standard version

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -38,7 +38,6 @@ jobs:
           git push origin ${{ github.event.pull_request.head.ref }} --force-with-lease
 
       - name: Enable auto-merge or merge pull request
-        run: |
-          gh pr merge ${{ github.event.pull_request.number }} --auto -m -d --subject "${{ github.event.pull_request.title }}"
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto -m -d
         env:
           GH_TOKEN: ${{ github.actor == 'dependabot[bot]' && secrets.DEPENDABOT_TOKEN || secrets.GH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -18,44 +18,40 @@
   "standard-version": {
     "types": [
       {
-        "type": "[FEATURE]",
+        "type": "feat",
         "section": "🚀 New features"
       },
       {
-        "type": "[BUGFIX]",
+        "type": "fix",
         "section": "🐛 Bug fixes"
       },
       {
-        "type": "[CHORE]",
+        "type": "chore",
         "section": "🔧 Chore"
       },
       {
-        "type": "[DOCS]",
+        "type": "docs",
         "section": "📚 Documentation"
       },
       {
-        "type": "[STYLES]",
+        "type": "style",
         "section": "💅 Styles"
       },
       {
-        "type": "[REFACTOR]",
+        "type": "refactor",
         "section": "🔨 Refactor"
       },
       {
-        "type": "[PERF]",
+        "type": "perf",
         "section": "⚡ Performance"
       },
       {
-        "type": "[TESTS]",
+        "type": "test",
         "section": "🧪 Tests"
       },
       {
-        "type": "[BUMP]",
+        "type": "bump",
         "section": "🔖 Version bump"
-      },
-      {
-        "type": "[TECH]",
-        "section": "🛠️ Technical"
       }
     ]
   },


### PR DESCRIPTION
This pull request includes changes to streamline the auto-merge process in the GitHub workflow and to standardize the commit message types in the `package.json` file.

Changes to GitHub workflow:

* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L41-R41): Simplified the auto-merge command by removing the pull request number and title parameters from the `gh pr merge` command.

Standardization of commit message types:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-L58): Updated the commit message types to use conventional commit types (e.g., `feat`, `fix`, `chore`, etc.) and removed the `[TECH]` type.