### PR TITLE
[TECH] Switch to commit and tag

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -38,7 +38,6 @@ jobs:
           git push origin ${{ github.event.pull_request.head.ref }} --force-with-lease
 
       - name: Enable auto-merge or merge pull request
-        run: |
-          gh pr merge ${{ github.event.pull_request.number }} --auto -m -d --subject "${{ github.event.pull_request.title }}"
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto -m -d
         env:
           GH_TOKEN: ${{ github.actor == 'dependabot[bot]' && secrets.DEPENDABOT_TOKEN || secrets.GH_TOKEN }}

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,40 @@
+{
+  "types": [
+    {
+      "type": "feat",
+      "section": "🚀 New features"
+    },
+    {
+      "type": "fix",
+      "section": "🐛 Bug fixes"
+    },
+    {
+      "type": "chore",
+      "section": "🔧 Chore"
+    },
+    {
+      "type": "docs",
+      "section": "📚 Documentation"
+    },
+    {
+      "type": "style",
+      "section": "💅 Styles"
+    },
+    {
+      "type": "refactor",
+      "section": "🔨 Refactor"
+    },
+    {
+      "type": "perf",
+      "section": "⚡ Performance"
+    },
+    {
+      "type": "test",
+      "section": "🧪 Tests"
+    },
+    {
+      "type": "bump",
+      "section": "🔖 Version bump"
+    }
+  ]
+}

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -38,8 +38,11 @@
     },
     {
       "type": "tech",
-      "section": "🛠️ Tech",
-      "hidden": false
+      "section": "🛠️ Tech"
+    },
+    {
+      "type": "revert",
+      "section": "⏪ Revert"
     }
   ]
 }

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -35,6 +35,11 @@
     {
       "type": "bump",
       "section": "🔖 Version bump"
+    },
+    {
+      "type": "tech",
+      "section": "🛠️ Tech",
+      "hidden": false
     }
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,6 +92,7 @@ export default [
       ".idea/",
       ".vscode/",
       "public/",
+      ".versionrc.json",
       "jsconfig.json",
       "package-lock.json",
       "package.json",

--- a/package.json
+++ b/package.json
@@ -18,44 +18,40 @@
   "standard-version": {
     "types": [
       {
-        "type": "[FEATURE]",
+        "type": "feat",
         "section": "🚀 New features"
       },
       {
-        "type": "[BUGFIX]",
+        "type": "fix",
         "section": "🐛 Bug fixes"
       },
       {
-        "type": "[CHORE]",
+        "type": "chore",
         "section": "🔧 Chore"
       },
       {
-        "type": "[DOCS]",
+        "type": "docs",
         "section": "📚 Documentation"
       },
       {
-        "type": "[STYLES]",
+        "type": "style",
         "section": "💅 Styles"
       },
       {
-        "type": "[REFACTOR]",
+        "type": "refactor",
         "section": "🔨 Refactor"
       },
       {
-        "type": "[PERF]",
+        "type": "perf",
         "section": "⚡ Performance"
       },
       {
-        "type": "[TESTS]",
+        "type": "test",
         "section": "🧪 Tests"
       },
       {
-        "type": "[BUMP]",
+        "type": "bump",
         "section": "🔖 Version bump"
-      },
-      {
-        "type": "[TECH]",
-        "section": "🛠️ Technical"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -12,48 +12,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "production": "sh script/release.sh",
-    "release": "standard-version",
+    "release": "commit-and-tag-version",
     "prepare": "husky"
-  },
-  "standard-version": {
-    "types": [
-      {
-        "type": "feat",
-        "section": "🚀 New features"
-      },
-      {
-        "type": "fix",
-        "section": "🐛 Bug fixes"
-      },
-      {
-        "type": "chore",
-        "section": "🔧 Chore"
-      },
-      {
-        "type": "docs",
-        "section": "📚 Documentation"
-      },
-      {
-        "type": "style",
-        "section": "💅 Styles"
-      },
-      {
-        "type": "refactor",
-        "section": "🔨 Refactor"
-      },
-      {
-        "type": "perf",
-        "section": "⚡ Performance"
-      },
-      {
-        "type": "test",
-        "section": "🧪 Tests"
-      },
-      {
-        "type": "bump",
-        "section": "🔖 Version bump"
-      }
-    ]
   },
   "dependencies": {
     "@pinia/testing": "^1.0.0",
@@ -73,6 +33,7 @@
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/test-utils": "^2.4.6",
+    "commit-and-tag-version": "^12.5.0",
     "eslint": "^9.20.1",
     "eslint-plugin-i18n-json": "^4.0.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -80,7 +41,6 @@
     "eslint-plugin-vue": "^9.23.0",
     "husky": "^9.1.7",
     "jsdom": "^26.0.0",
-    "standard-version": "^9.5.0",
     "vite": "^6.1.0",
     "vitest": "^3.0.5"
   }


### PR DESCRIPTION
This pull request includes several changes aimed at improving the release process and configuration management. The most important changes include replacing `standard-version` with `commit-and-tag-version`, updating the `.versionrc.json` file, and modifying the GitHub Actions workflow for auto-merging pull requests.

Release process improvements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-L61): Replaced `standard-version` with `commit-and-tag-version` for the release process. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-L61) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R36-L87)
* [`.versionrc.json`](diffhunk://#diff-fc8675bd9292cdcdca740165c0b6c7d0d531a4fec0f279606aef2fb380adc81cR1-R48): Added a new configuration file to define commit types and their corresponding sections for versioning.

Configuration management:

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R95): Added `.versionrc.json` to the list of ignored files.

GitHub Actions workflow:

* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L41-R41): Simplified the command to enable auto-merge or merge pull requests by removing the `--subject` option.