### PR TITLE
[TECH] Configure the release workflow for semantic version

### DIFF
--- a/.github/workflows/build-version.yml
+++ b/.github/workflows/build-version.yml
@@ -5,11 +5,6 @@ name: "Build version"
 
 on:
   workflow_dispatch:
-    inputs:
-      release_type:
-        description: "The type of release to generate"
-        required: true
-        default: "patch"
 
 permissions:
   contents: write
@@ -19,13 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if input is valid
-        run: |
-          if [[ "${{ github.event.inputs.release_type }}" != "major" && "${{ github.event.inputs.release_type }}" != "minor" && "${{ github.event.inputs.release_type }}" != "patch" ]]; then
-            echo "Invalid release type. Please use 'major', 'minor' or 'patch'."
-            exit 1
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -50,8 +38,7 @@ jobs:
           npm run lint
 
       - name: Build new version
-        # Use standard-version to generate a new version
-        run: npm run release -- --release-as ${{ github.event.inputs.release_type }}
+        run: npm run release
 
       - name: Push new version
         run: git push --follow-tags origin main


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build-version.yml` file to simplify the build version workflow by removing the input validation and the release type input.

Simplifications to build version workflow:

* [`.github/workflows/build-version.yml`](diffhunk://#diff-c8e0932e362c6cf2133d2797ec3edf7699d897d626a9f35f5e156ddc27636516L8-L12): Removed the `inputs` section and its associated `release_type` input.
* [`.github/workflows/build-version.yml`](diffhunk://#diff-c8e0932e362c6cf2133d2797ec3edf7699d897d626a9f35f5e156ddc27636516L22-L28): Removed the step that checks if the `release_type` input is valid.
* [`.github/workflows/build-version.yml`](diffhunk://#diff-c8e0932e362c6cf2133d2797ec3edf7699d897d626a9f35f5e156ddc27636516L53-R41): Modified the `Build new version` step to no longer use the `release_type` input.