### PR TITLE
[BUGFIX] Customize the style of components

### DIFF
--- a/src/components/LanguageComponent.vue
+++ b/src/components/LanguageComponent.vue
@@ -23,7 +23,7 @@ export default {
 <template>
   <div class="flex gap-2">
     <label for="language">{{ $t('languages.select') }}</label>
-    <select :value="current_language" v-model="current_language" @change="changeLanguage">
+    <select :value="current_language" v-model="current_language" @change="changeLanguage" class="custom-select">
       <option v-for="language in $i18n.availableLocales" :key="language" :value="language">
         {{ $t(`languages.${language}`) }}
       </option>

--- a/src/components/SettingComponent.vue
+++ b/src/components/SettingComponent.vue
@@ -56,7 +56,7 @@ export default {
       :checked="settingValue"
       @change="updateSetting"
       v-model="settingValue"
-      class="h-4 w-4 text-blue-600 border-gray-300 rounded-sm focus:ring-blue-500"
+      class="h-4 w-4 text-blue-600 border-gray-300 rounded-sm focus:ring-blue-500 custom-input"
     />
 
     <!-- Dropdown menu -->
@@ -67,7 +67,7 @@ export default {
       :name="name"
       @change="updateSetting"
       v-model="settingValue"
-      class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-xs focus:outline-hidden focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+      class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-xs focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm custom-input"
     >
       <option v-for="option in setting.values" :key="option" :value="option" :name="option">
         {{ !setting.isTranslate ? $t(`settings.values.${option}`) : option }}
@@ -85,7 +85,7 @@ export default {
       :value="settingValue"
       @input="updateSetting"
       v-model="settingValue"
-      class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs focus:outline-hidden focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+      class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm custom-input"
     />
 
     <!-- Text input -->
@@ -97,12 +97,12 @@ export default {
       :value="settingValue"
       @input="updateSetting"
       v-model="settingValue"
-      class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs focus:outline-hidden focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+      class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-xs focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm custom-input"
     />
     <!-- Button to set the default value -->
     <button
       @click="setDefault"
-      class="mt-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-sm"
+      class="mt-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-sm custom-button"
       v-if="settingValue!==setting.default">
       {{ $t("settings.values.default") }}
     </button>

--- a/src/components/UploadFileComponent.vue
+++ b/src/components/UploadFileComponent.vue
@@ -41,8 +41,8 @@ export default {
     <h2 class="text-3xl">{{$t('uploadFile.title')}}</h2>
     <form @submit.prevent="uploadFile" class="flex flex-col">
       <label for="select">{{$t('uploadFile.select')}}</label>
-      <input type="file" id="select" @change="handleFileUpload" accept=".bnote" required />
-      <button type="submit" class="w-fit p-2 rounded mt-2 bg-green-700 hover:bg-transparent hover:text-green-300 hover:scale-95 hover:border-green-300 border border-green-700 transition-all duration-200">{{$t('uploadFile.show')}}</button>
+      <input type="file" id="select" @change="handleFileUpload" accept=".bnote" required class="custom-input" />
+      <button type="submit" class="w-fit p-2 rounded mt-2 bg-green-700 hover:bg-transparent hover:text-green-300 hover:scale-95 hover:border-green-300 border border-green-700 transition-all duration-200 custom-button">{{$t('uploadFile.show')}}</button>
     </form>
   </div>
 </template>

--- a/src/style.css
+++ b/src/style.css
@@ -9,53 +9,43 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentColor);
-  }
+    *,
+    ::after,
+    ::before,
+    ::backdrop,
+    ::file-selector-button {
+        border-color: var(--color-gray-200, currentColor);
+    }
 }
 
+/* Reset global styles */
 * {
-    margin: 2rem;
-    padding: 1rem;
+    margin: 0;
+    padding: 0;
     box-sizing: border-box;
-    color: white;
 }
 
-html {
-    height: 100dvh;
-    width: 100dvw;
+/* Global styles */
+body {
+    color: white;
     background-color: rgb(2 6 23);
     display: flex;
     flex-direction: column;
-}
-
-body {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
+    min-height: 100vh;
     width: 100%;
-    overflow: hidden;
 }
 
 #app {
     display: flex;
-    width: 100%;
     flex-direction: column;
     flex-grow: 1;
-    overflow: hidden;
+    width: 100%;
 }
 
-select {
-    color: black;
-    width: fit-content;
-    background-color: rgb(195, 195, 195);
-}
-
-button {
+/* Custom styles for inputs, buttons, and selects */
+.custom-input,
+.custom-button,
+.custom-select {
     background-color: rgb(195, 195, 195);
     color: black;
     border: none;
@@ -63,13 +53,13 @@ button {
     cursor: pointer;
 }
 
-input {
-    background-color: rgb(195, 195, 195);
-    color: black;
-    border: none;
-    padding: 0.5rem 1rem;
+/* Ensure selects and inputs are readable */
+.custom-input,
+.custom-select {
+    width: fit-content;
 }
 
+/* Specific styles for setting components */
 .setting {
     display: flex;
     flex-direction: column;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -139,7 +139,7 @@ export default {
       <button
         type="button"
         @click="createBasicData"
-        class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+        class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 custom-button"
       >
         {{ $t("settings.page.create") }}
       </button>
@@ -167,7 +167,7 @@ export default {
           <button
             type="button"
             @click="togle_menu(section)"
-            class="mt-2 text-sm text-blue-600 hover:underline focus:outline-none"
+            class="mt-2 text-sm text-blue-600 hover:underline focus:outline-none custom-button"
           >
             {{ display_menu[section] ? $t('settings.page.hide') : $t('settings.page.show') }}
           </button>
@@ -185,7 +185,7 @@ export default {
 
         <button
           type="submit"
-          class="w-full px-4 py-2 bg-green-500 text-white font-medium rounded-md hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+          class="w-full px-4 py-2 bg-green-500 text-white font-medium rounded-md hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400 custom-button"
         >
           {{ $t("settings.page.download") }}
         </button>
@@ -194,7 +194,7 @@ export default {
       <button
         type="button"
         @click="clean_data"
-        class="mt-4 w-full px-4 py-2 bg-red-500 text-white font-medium rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400"
+        class="mt-4 w-full px-4 py-2 bg-red-500 text-white font-medium rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 custom-button"
       >
         {{ $t("settings.page.openOther") }}
       </button>


### PR DESCRIPTION
This pull request focuses on enhancing the consistency and readability of the UI components by introducing custom CSS classes and resetting global styles. The changes span across multiple Vue components and the main stylesheet.

### UI Component Enhancements:

* [`src/components/LanguageComponent.vue`](diffhunk://#diff-e4549888235201835af39686be6a12f253ad3cf5a47d20d5040a6e2d90779e43L26-R26): Added the `custom-select` class to the language dropdown for consistent styling.
* [`src/components/SettingComponent.vue`](diffhunk://#diff-4b510c76d34984739ba35e177e172004533c9000a381ecd3963ab3b20b28b851L59-R59): Applied the `custom-input` and `custom-button` classes to various input elements and buttons to standardize their appearance. [[1]](diffhunk://#diff-4b510c76d34984739ba35e177e172004533c9000a381ecd3963ab3b20b28b851L59-R59) [[2]](diffhunk://#diff-4b510c76d34984739ba35e177e172004533c9000a381ecd3963ab3b20b28b851L70-R70) [[3]](diffhunk://#diff-4b510c76d34984739ba35e177e172004533c9000a381ecd3963ab3b20b28b851L88-R88) [[4]](diffhunk://#diff-4b510c76d34984739ba35e177e172004533c9000a381ecd3963ab3b20b28b851L100-R105)
* [`src/components/UploadFileComponent.vue`](diffhunk://#diff-bd9f944f416afa6444a3bf9b8f36a35b9ddb877861404829691e888487c57af5L44-R45): Added `custom-input` and `custom-button` classes to the file input and submit button for uniform styling.

### Global Style Adjustments:

* [`src/style.css`](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R21-R62): Reset global styles by removing default margins and padding, and introduced custom styles for inputs, buttons, and selects to ensure consistency across the application.

### Settings View Updates:

* [`src/views/SettingsView.vue`](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6L142-R142): Applied the `custom-button` class to various buttons in the settings view for a cohesive look. [[1]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6L142-R142) [[2]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6L170-R170) [[3]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6L188-R188) [[4]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6L197-R197) 