### PR TITLE
[TECH] Remove the pull request assignment to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
       - Ready to merge
     reviewers:
       - theotime2005
-    assignees:
-      - dependabot
     commit-message:
       prefix: "[BUMP]"
       include: scope
@@ -27,13 +25,11 @@ updates:
       time: '00:00'
     open-pull-requests-limit: 2
     labels:
-      - dependencies
+      - No deployment
       - workflow
       - Ready to merge
     reviewers:
       - theotime2005
-    assignees:
-      - dependabot
     commit-message:
       prefix: "[BUMP]"
       include: scope


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` file. The changes focus on modifying the labels and removing the assignees for Dependabot updates.

Key changes:

* Removed the `assignees` section, which previously assigned Dependabot pull requests to the `dependabot` user.
* Changed the label from `dependencies` to `No deployment` for Dependabot pull requests.