### PR TITLE
[TECH] Use the dependabots commands to merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,9 +22,9 @@ permissions:
   contents: read
 
 jobs:
-  auto_merge:
+  auto_merge_standard:
     runs-on: ubuntu-latest
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge') && github.event.pull_request.draft == false
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge') && github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout repository
@@ -48,3 +48,21 @@ jobs:
         run: gh pr merge ${{ github.event.pull_request.number }} --auto -m -d
         env:
           GH_TOKEN: ${{ github.actor == 'dependabot[bot]' && secrets.DEPENDABOT_TOKEN || secrets.GH_TOKEN }}
+
+  merge_dependabot:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'Ready to merge') && github.event.pull_request.draft == false && github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Ask rebase to dependabot
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "@dependabot rebase"
+        env:
+            token: ${{ secrets.DEPENDABOT_TOKEN }}
+
+      - name: Ask merge to dependabot
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "@dependabot merge"
+        env:
+          token: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
This pull request includes significant changes to the `.github/workflows/auto-merge.yml` file, aimed at improving the auto-merge process by differentiating between standard pull requests and those created by Dependabot. The most important changes include renaming the auto-merge job, adding a new job specifically for Dependabot, and updating conditions for running these jobs.

Changes to auto-merge process:

* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L25-R27): Renamed the `auto_merge` job to `auto_merge_standard` and updated the condition to exclude Dependabot as the actor.
* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243R51-R68): Added a new job `merge_dependabot` to handle auto-merging of Dependabot pull requests, including steps for checking out code, requesting a rebase, and merging.