### PR TITLE
[TECH] Using MODE environment variable

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -5,9 +5,3 @@
 # Type string
 # Url to send api messages
 # VUE_APPLOG_API_URL=""
-
-# type string
-# Environment using
-# Accept: development, production
-# default value is development
-# VUE_APP_ENVIRONMENT=

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,11 +43,11 @@ export default {
     if (localeCookie) {
       this.$i18n.locale = localeCookie;
       this.hasLanguage = true;
-    } else if (process.env.VUE_APP_ENVIRONMENT === "test") {
+    } else if (import.meta.env.MODE==="test") {
       this.hasLanguage = true;
     }
     // Toggle the reset cookies variable
-    if (process.env.VUE_APP_ENVIRONMENT === "development") {
+    if (import.meta.env.MODE=== "development") {
       this.canReset = true;
     }
   },

--- a/src/__tests__/acceptance/DownloadPageView.spec.js
+++ b/src/__tests__/acceptance/DownloadPageView.spec.js
@@ -1,17 +1,26 @@
 import { render } from "@/__tests__/acceptance/helper.js";
 
 describe("Acceptance | DownloadPageView", () => {
-  beforeEach(() => {
+  beforeEach(function() {
+    global["fetch"] = vi.fn(() => Promise.resolve({}));
+  });
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   it("Displays the main title", async () => {
+    // when
     const wrapper = await render("/download");
+
+    // then
     expect(wrapper.html()).toContain("download.title");
   });
 
   it("Displays eurobraille links", async () => {
+    // when
     const wrapper = await render("/download");
+
+    // then
     const eurobrailleLink = wrapper.find(
       "a[href=\"https://www.eurobraille.fr/supports-et-telechargements/produits-braille/b-note/\"]",
     );
@@ -20,7 +29,10 @@ describe("Acceptance | DownloadPageView", () => {
   });
 
   it("displays Theotime links", async () => {
+    // when
     const wrapper = await render("/download");
+
+    // then
     const theotimeGitHubLink = wrapper.find(
       "a[href=\"https://github.com/theotime2005/bnote\"]",
     );
@@ -30,23 +42,29 @@ describe("Acceptance | DownloadPageView", () => {
 
     expect(theotimeGitHubLink.exists()).toBe(true);
     expect(theotimeGitHubLink.text()).toContain("download.message-3-1");
-
     expect(theotimeReleasesLink.exists()).toBe(true);
     expect(theotimeReleasesLink.text()).toBe("download.releases");
   });
 
   it("Manage errors when loading last version", async () => {
+    // given
     global.fetch = vi.fn(() => Promise.reject("Network error"));
 
+    // when
     const wrapper = await render("/download");
+
+    // then
     await wrapper.vm.$nextTick();
     expect(global.fetch).toHaveBeenCalledWith(
       "https://api.github.com/repos/theotime2005/bnote/releases",
     );
   });
 
-  it("affiche correctement les traductions", async () => {
+  it("should display correctly translations", async () => {
+    // when
     const wrapper = await render("/download");
+
+    // then
     expect(wrapper.html()).toContain("download.message-1");
     expect(wrapper.html()).toContain("download.message2");
     expect(wrapper.html()).toContain("download.message3");

--- a/src/__tests__/scripts/update_translation.spec.js
+++ b/src/__tests__/scripts/update_translation.spec.js
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import translatte from "translatte";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   checkAndUpdate,
@@ -17,13 +17,13 @@ const mockFs = vi.mocked(fs);
 const mockTranslatte = vi.mocked(translatte);
 
 describe("Translation Script", () => {
-  beforeAll(() => {
+  beforeEach(() => {
     mockTranslatte.mockImplementation((text, options) => {
       return Promise.resolve({ text: `${text}-${options.to}` });
     });
   });
 
-  afterAll(() => {
+  afterEach(() => {
     mockTranslatte.mockRestore();
   });
 
@@ -93,8 +93,8 @@ describe("Translation Script", () => {
     const updated = await checkAndUpdate(source, other, language);
 
     expect(updated).toEqual({
-      nested: { key1: "oldValue", key2: "*value2" },
-      key3: "*value3",
+      nested: { key1: "oldValue", key2: "*value2-fr" },
+      key3: "*value3-fr",
     });
   });
 

--- a/src/__tests__/vite.config.setup.test.js
+++ b/src/__tests__/vite.config.setup.test.js
@@ -1,0 +1,8 @@
+beforeEach(function() {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(function() {
+  vi.restoreAllMocks();
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,24 +4,21 @@ import tailwindcss from "@tailwindcss/vite";
 import vue from "@vitejs/plugin-vue";
 import { dirname } from "path";
 import { defineConfig, loadEnv } from "vite";
-import vitePluginEnvCompatible from "vite-plugin-env-compatible";
 
 import packageInfo from "./package.json";
 import { sendLog } from "./src/scripts/send-error-message-script.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const env = loadEnv(process.env.MODE || "development", __dirname);
-const VUE_APP_ENVIRONMENT = env.VUE_APP_ENVIRONMENT || "development";
 
 export default defineConfig({
   plugins: [
     tailwindcss(),
     vue(),
-    vitePluginEnvCompatible(),
     {
       name: "show-success-message",
       closeBundle() {
-        if (process.env.VUE_APP_ENVIRONMENT === "production") {
+        if (env === "production") {
           sendLog({
             fileName: "Vite config",
             functionName: "closeBundle",
@@ -36,9 +33,5 @@ export default defineConfig({
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
-  },
-  define: {
-    __APP_ENV__: JSON.stringify(env.APP_ENV),
-    "process.env.VUE_APP_ENVIRONMENT": JSON.stringify(VUE_APP_ENVIRONMENT),
   },
 });

--- a/vite.config.setup.test.js
+++ b/vite.config.setup.test.js
@@ -1,4 +1,0 @@
-// eslint-disable-next-line no-undef
-vi.spyOn(console, "error").mockImplementation(() => {});
-// eslint-disable-next-line no-undef
-vi.spyOn(global, "fetch").mockImplementation(() => Promise.resolve({}));

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -15,9 +15,5 @@ export default mergeConfig(
       root: fileURLToPath(new URL("./", import.meta.url)),
       reporters: process.env.GITHUB_ACTIONS ? ["dot", "github-actions"] : ["dot"],
     },
-    define: {
-      __DEV__: true,
-      "process.env.VUE_APP_ENVIRONMENT": "\"test\"",
-    },
   }),
 );

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      setupFiles: "./vite.config.setup.test.js",
+      setupFiles: "src/__tests__/vite.config.setup.test.js",
       globals: true,
       environment: "jsdom",
       exclude: [...configDefaults.exclude, "e2e/**"],


### PR DESCRIPTION
This pull request includes several changes to improve the environment configuration and testing setup. Key changes include the removal of unused environment variables, updates to the testing framework, and modifications to the environment variable handling in the codebase.

### Environment Configuration:
* Removed unused environment variables from `sample.env`.
* Updated environment variable handling in `src/App.vue` to use `import.meta.env.MODE` instead of `process.env.VUE_APP_ENVIRONMENT`.
* Removed `vite-plugin-env-compatible` and related environment variable definitions from `vite.config.js`. [[1]](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L7-R21) [[2]](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L40-L43)

### Testing Setup:
* Modified `beforeEach` and `afterEach` hooks in `src/__tests__/acceptance/DownloadPageView.spec.js` to mock `fetch` and reset mocks after each test. [[1]](diffhunk://#diff-edc27cec1e7ae0287148790cc8dbb1d67820b946399062a601b509e20947a1e7L4-R23) [[2]](diffhunk://#diff-edc27cec1e7ae0287148790cc8dbb1d67820b946399062a601b509e20947a1e7R32-R35) [[3]](diffhunk://#diff-edc27cec1e7ae0287148790cc8dbb1d67820b946399062a601b509e20947a1e7L33-R67)
* Changed `beforeAll` and `afterAll` hooks to `beforeEach` and `afterEach` in `src/__tests__/scripts/update_translation.spec.js` for better isolation between tests. [[1]](diffhunk://#diff-0e33564b2686c038d929342f83868867a9d9e783cfc458127449ff421fadca54L3-R3) [[2]](diffhunk://#diff-0e33564b2686c038d929342f83868867a9d9e783cfc458127449ff421fadca54L20-R26)
* Added `beforeEach` and `afterEach` hooks in `src/__tests__/vite.config.setup.test.js` to mock `console.error` and `console.log`.
* Updated `vitest.config.js` to use the correct setup file path and removed unnecessary environment variable definitions.