### PR TITLE
[REVERT] Revert the merge by dependabot

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,9 +22,9 @@ permissions:
   contents: read
 
 jobs:
-  auto_merge_standard:
+  auto_merge:
     runs-on: ubuntu-latest
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge') && github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge') && github.event.pull_request.draft == false
 
     steps:
       - name: Checkout repository
@@ -48,21 +48,3 @@ jobs:
         run: gh pr merge ${{ github.event.pull_request.number }} --auto -m -d
         env:
           GH_TOKEN: ${{ github.actor == 'dependabot[bot]' && secrets.DEPENDABOT_TOKEN || secrets.GH_TOKEN }}
-
-  merge_dependabot:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'Ready to merge') && github.event.pull_request.draft == false && github.actor == 'dependabot[bot]'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Ask rebase to dependabot
-        run: gh pr comment ${{ github.event.pull_request.number }} --body "@dependabot rebase"
-        env:
-            token: ${{ secrets.DEPENDABOT_TOKEN }}
-
-      - name: Ask merge to dependabot
-        run: gh pr comment ${{ github.event.pull_request.number }} --body "@dependabot merge"
-        env:
-          token: ${{ secrets.DEPENDABOT_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ github.actor == 'dependabot[bot]' && secrets.DEPENDABOT_TOKEN || secrets.GH_TOKEN }}
 
       - name: Rebase branch before merge
         run: |
@@ -47,23 +47,22 @@ jobs:
       - name: Enable auto-merge or merge pull request
         run: gh pr merge ${{ github.event.pull_request.number }} --auto -m -d
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.actor == 'dependabot[bot]' && secrets.DEPENDABOT_TOKEN || secrets.GH_TOKEN }}
 
   merge_dependabot:
     runs-on: ubuntu-latest
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge') && github.event.pull_request.draft == false && github.actor == 'dependabot[bot]'
+    if: contains(github.event.pull_request.labels.*.name, 'Ready to merge') && github.event.pull_request.draft == false && github.actor == 'dependabot[bot]'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.DEPENDABOT_TOKEN }}
 
       - name: Ask rebase to dependabot
         run: gh pr comment ${{ github.event.pull_request.number }} --body "@dependabot rebase"
         env:
-            GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+            token: ${{ secrets.DEPENDABOT_TOKEN }}
 
       - name: Ask merge to dependabot
         run: gh pr comment ${{ github.event.pull_request.number }} --body "@dependabot merge"
         env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+          token: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
This pull request simplifies and consolidates the auto-merge workflow in the `.github/workflows/auto-merge.yml` file by merging the `auto_merge_standard` and `merge_dependabot` jobs into a single `auto_merge` job. The changes ensure that the correct token is used based on the actor.

Consolidation of auto-merge workflow:

* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L25-R33): Renamed `auto_merge_standard` job to `auto_merge` and removed the `merge_dependabot` job. Updated the token logic to use `DEPENDABOT_TOKEN` if the actor is `dependabot[bot]`, otherwise use `GH_TOKEN`. [[1]](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L25-R33) [[2]](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L50-R50)