### PR TITLE
[TECH] Change the vite configuration

### DIFF
--- a/src/__tests__/scripts/send-log-message-script.spec.js
+++ b/src/__tests__/scripts/send-log-message-script.spec.js
@@ -1,4 +1,4 @@
-import { sendLog } from "@/scripts/send-error-message-script.js";
+import { sendLog } from "@/scripts/send-log-message-script.js";
 
 describe("scripts | sendLog", () => {
   let fetch;

--- a/src/components/UploadFileComponent.vue
+++ b/src/components/UploadFileComponent.vue
@@ -1,5 +1,5 @@
 <script>
-import { sendLog } from "@/scripts/send-error-message-script.js";
+import { sendLog } from "@/scripts/send-log-message-script.js";
 import { useSettingsStore } from "@/stores/settingsStore.js";
 export default {
   name: "UploadFileComponent",

--- a/src/scripts/send-error-message-script.js
+++ b/src/scripts/send-error-message-script.js
@@ -12,7 +12,7 @@ async function sendLog({ fileName, functionName, type, log }) {
   };
   // Log the message in the console for Vercel deployment
   console.log(message);
-  const apiUrl = process.env.VUE_APP_LOG_API_URL || null;
+  const apiUrl = import.meta.env.VUE_APP_LOG_API_URL || null;
   if (!apiUrl) {
     console.log("Message not sent, no API URL");
     return;

--- a/src/scripts/send-log-message-script.js
+++ b/src/scripts/send-log-message-script.js
@@ -2,7 +2,7 @@
 This file is used to send a notification on the discord server when an error occurs.
  */
 
-async function sendLog({ fileName, functionName, type, log }) {
+async function sendLog({ fileName, functionName, type, log, environment = true }) {
   const redColor = 16711680;
   // Create a message visible and readable
   const message = {
@@ -12,7 +12,7 @@ async function sendLog({ fileName, functionName, type, log }) {
   };
   // Log the message in the console for Vercel deployment
   console.log(message);
-  const apiUrl = import.meta.env.VUE_APP_LOG_API_URL || null;
+  const apiUrl = environment ? import.meta.env.VUE_APP_LOG_API_URL : process.env.VUE_APP_LOG_API_URL;
   if (!apiUrl) {
     console.log("Message not sent, no API URL");
     return;

--- a/src/views/DownloadPageView.vue
+++ b/src/views/DownloadPageView.vue
@@ -1,5 +1,5 @@
 <script>
-import { sendLog } from "@/scripts/send-error-message-script.js";
+import { sendLog } from "@/scripts/send-log-message-script.js";
 
 export default {
   name: "DownloadPageView",

--- a/src/views/FaqView.vue
+++ b/src/views/FaqView.vue
@@ -1,5 +1,5 @@
 <script>
-import { sendLog } from "@/scripts/send-error-message-script.js";
+import { sendLog } from "@/scripts/send-log-message-script.js";
 
 export default {
   name: "FaqView",

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 
 import packageInfo from "./package.json";
-import { sendLog } from "./src/scripts/send-error-message-script.js";
+import { sendLog } from "./src/scripts/send-log-message-script.js";
 
 export default defineConfig(({ mode }) => {
   const config = {

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,36 +2,32 @@ import { fileURLToPath, URL } from "node:url";
 
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@vitejs/plugin-vue";
-import { dirname } from "path";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 
 import packageInfo from "./package.json";
 import { sendLog } from "./src/scripts/send-error-message-script.js";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const env = loadEnv(process.env.MODE || "development", __dirname);
-
-export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    vue(),
-    {
-      name: "show-success-message",
-      closeBundle() {
-        if (env === "production") {
-          sendLog({
-            fileName: "Vite config",
-            functionName: "closeBundle",
-            type: "success",
-            log: `Congratulations! the version ${packageInfo.version} is deployed successfully!`,
-          });
-        }
+export default defineConfig(({ mode }) => {
+  const config = {
+    plugins: [
+      vue(),
+      tailwindcss(),
+    ],
+    resolve: {
+      alias: {
+        "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
     },
-  ],
-  resolve: {
-    alias: {
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
-    },
-  },
+  };
+  if (mode === "production") {
+    sendLog({
+      fileName: "config",
+      functionName: "main",
+      type: "info",
+      log: `Building ${packageInfo.name} ${packageInfo.version} for production`,
+      environment: false,
+    });
+  }
+
+  return config;
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,7 +2,11 @@ import { fileURLToPath } from "node:url";
 
 import { configDefaults, defineConfig, mergeConfig } from "vitest/config";
 
-import viteConfig from "./vite.config";
+import baseViteConfig from "./vite.config";
+
+const viteConfig = typeof baseViteConfig === "function"
+  ? baseViteConfig({ mode: "test" })
+  : baseViteConfig;
 
 export default mergeConfig(
   viteConfig,


### PR DESCRIPTION
This pull request focuses on renaming and updating the `send-error-message-script.js` to `send-log-message-script.js`, modernizing environment variable usage, and refactoring configuration files. Below are the most important changes grouped by theme.

### Script Renaming and Updates:
* Renamed `send-error-message-script.js` to `send-log-message-script.js` and updated all relevant imports across the codebase, including `UploadFileComponent.vue`, `DownloadPageView.vue`, and `FaqView.vue`. [[1]](diffhunk://#diff-c424b05fc57c2a26c59426902698a34f21e4c39d8316e05a709a3aa33e487fbfL1-R1) [[2]](diffhunk://#diff-bd9f944f416afa6444a3bf9b8f36a35b9ddb877861404829691e888487c57af5L2-R2) [[3]](diffhunk://#diff-611b70bedce12a6cbc6642e1de902ec1aca842de0f9222a98dd630165d90747cL2-R2) [[4]](diffhunk://#diff-5db7ce3b98b31cfb36415a5bd4dddf9bd22e3070c9b7f3ab40d2fefe61dc99b9L2-R2)
* Updated the `sendLog` function in `send-log-message-script.js` to use `import.meta.env` instead of `process.env` for accessing environment variables, aligning with Vite's best practices.

### Configuration File Refactoring:
* Refactored `vite.config.js` to streamline the configuration function, replacing `loadEnv` with a `mode` parameter and moving the `sendLog` call for production builds into the main configuration function. Removed unnecessary `dirname` logic.
* Updated `vitest.config.js` to handle `vite.config.js` as a function when importing, ensuring compatibility with the new configuration structure.