### PR TITLE
[TECH] Remove the unused id of settings file

### DIFF
--- a/src/__tests__/settings.test.js
+++ b/src/__tests__/settings.test.js
@@ -5,9 +5,6 @@ describe("unit | Settings", () => {
   describe("# Check the format of settings", () => {
     it("should format of settings is correct", () => {
       function checkSettingsIntegrity(setting) {
-        if (!setting.id) {
-          return false;
-        }
         switch (setting.type) {
         case "menu":
           if (!setting.values) {

--- a/src/settings.json
+++ b/src/settings.json
@@ -1,7 +1,6 @@
 {
   "system": {
     "braille_type": {
-      "id": "braille_type",
       "type": "menu",
       "values": [
         "dot-8",
@@ -11,22 +10,18 @@
       "default": "dot-8"
     },
     "auto_sync_date": {
-      "id": "auto_sync_date",
       "type": "checkbox",
       "default": false
     },
     "spaces_in_label": {
-      "id": "spaces_in_label",
       "type": "checkbox",
       "default": false
     },
     "shortcuts_visible": {
-      "id": "shortcuts_visible",
       "type": "checkbox",
       "default": false
     },
     "app_explorer": {
-      "id": "app_explorer",
       "type": "menu",
       "values": [
         "invisible",
@@ -36,7 +31,6 @@
       "default": "main_apps_menu"
     },
     "app_settings": {
-      "id": "app_settings",
       "type": "menu",
       "values": [
         "main_apps_menu",
@@ -45,7 +39,6 @@
       "default": "main_apps_menu"
     },
     "app_agenda": {
-      "id": "app_agenda",
       "type": "menu",
       "values": [
         "invisible",
@@ -55,7 +48,6 @@
       "default": "invisible"
     },
     "app_radio": {
-      "id": "app_radio",
       "type": "menu",
       "values": [
         "invisible",
@@ -65,7 +57,6 @@
       "default": "invisible"
     },
     "app_mp3": {
-      "id": "app_mp3",
       "type": "menu",
       "values": [
         "invisible",
@@ -75,7 +66,6 @@
       "default": "invisible"
     },
     "app_timer": {
-      "id": "app_timer",
       "type": "menu",
       "values": [
         "invisible",
@@ -85,7 +75,6 @@
       "default": "invisible"
     },
     "app_translator": {
-      "id": "app_translator",
       "type": "menu",
       "values": [
         "invisible",
@@ -95,7 +84,6 @@
       "default": "invisible"
     },
     "app_wikipedia": {
-      "id": "app_wikipedia",
       "type": "menu",
       "values": [
         "invisible",
@@ -105,7 +93,6 @@
       "default": "invisible"
     },
     "app_write_word": {
-      "id": "app_write_word",
       "type": "menu",
       "values": [
         "invisible",
@@ -115,7 +102,6 @@
       "default": "invisible"
     },
     "app_operation": {
-      "id": "app_operation",
       "type": "menu",
       "values": [
         "invisible",
@@ -125,7 +111,6 @@
       "default": "invisible"
     },
     "app_mines": {
-      "id": "app_mines",
       "type": "menu",
       "values": [
         "invisible",
@@ -135,7 +120,6 @@
       "default": "invisible"
     },
     "app_mastermind": {
-      "id": "app_mastermind",
       "type": "menu",
       "values": [
         "invisible",
@@ -145,41 +129,34 @@
       "default": "invisible"
     },
     "developer": {
-      "id": "developer",
       "type": "checkbox",
       "default": false
     }
   },
   "bluetooth": {
     "bnote_visible": {
-      "id": "bnote_visible",
       "type": "checkbox",
       "default": true
     },
     "bnote_name": {
-      "id": "bnote_name",
       "type": "text",
       "default": ""
     },
     "bt_simul_esys": {
-      "id": "bt_simul_esys",
       "type": "checkbox",
       "default": false
     }
   },
   "explorer": {
     "empty_bluetooth_shutdown": {
-      "id": "empty_bluetooth_shutdown",
       "type": "checkbox",
       "default": false
     },
     "empty_trash_shutdown": {
-      "id": "empty_trash_shutdown",
       "type": "checkbox",
       "default": false
     },
     "number_recent_files": {
-      "id": "number_recent_files",
       "type": "number",
       "min": 1,
       "max": 30,
@@ -188,7 +165,6 @@
   },
   "editor": {
     "braille_type": {
-      "id": "braille_type",
       "type": "menu",
       "values": [
         "dot-8",
@@ -198,24 +174,20 @@
       "default": "dot-8"
     },
     "line_length": {
-      "id": "line_length",
       "type": "number",
       "min": 1,
       "max": 160,
       "default": 80
     },
     "dot78_visible": {
-      "id": "dot78_visible",
       "type": "checkbox",
       "default": true
     },
     "cursor_visible": {
-      "id": "cursor_visible",
       "type": "checkbox",
       "default": true
     },
     "forward_display_mode": {
-      "id": "forward_display_mode",
       "type": "menu",
       "values": [
         "normal",
@@ -224,7 +196,6 @@
       "default": "normal"
     },
     "autoscroll": {
-      "id": "autoscroll",
       "type": "number",
       "min": 2,
       "max": 120,
@@ -233,7 +204,6 @@
   },
   "math": {
     "angle": {
-      "id": "angle",
       "type": "menu",
       "values": [
         "degree",
@@ -242,19 +212,16 @@
       "default": "radian"
     },
     "fraction": {
-      "id": "fraction",
       "type": "checkbox",
       "default": true
     },
     "precision": {
-      "id": "precision",
       "type": "number",
       "min": 0,
       "max": 8,
       "default": 2
     },
     "format": {
-      "id": "format",
       "type": "menu",
       "values": [
         "scientific",
@@ -265,7 +232,6 @@
   },
   "music_xml": {
     "edit_mode": {
-      "id": "edit_mode",
       "type": "menu",
       "values": [
         "expert",
@@ -276,7 +242,6 @@
       "default": "read"
     },
     "braille_type": {
-      "id": "braille_type",
       "type": "menu",
       "values": [
         "dot-8",
@@ -285,7 +250,6 @@
       "default": "dot-8"
     },
     "notes_dots": {
-      "id": "notes_dots",
       "type": "menu",
       "values": [
         "8_dots",
@@ -295,22 +259,18 @@
       "default": "6_dots_with_group"
     },
     "ascending_chords": {
-      "id": "ascending_chords",
       "type": "checkbox",
       "default": true
     },
     "fingering": {
-      "id": "fingering",
       "type": "checkbox",
       "default": true
     },
     "clef": {
-      "id": "clef",
       "type": "checkbox",
       "default": true
     },
     "parts": {
-      "id": "parts",
       "type": "menu",
       "values": [
         "name",
@@ -319,24 +279,20 @@
       "default": "name"
     },
     "measure_b123": {
-      "id": "measure_b123",
       "type": "checkbox",
       "default": false
     },
     "measure_number": {
-      "id": "measure_number",
       "type": "checkbox",
       "default": false
     },
     "measure_every": {
-      "id": "measure_every",
       "type": "number",
       "min": 1,
       "max": 100,
       "default": 1
     },
     "view": {
-      "id": "view",
       "type": "menu",
       "values": [
         "by_section",
@@ -345,7 +301,6 @@
       "default": "by_section"
     },
     "section": {
-      "id": "section",
       "type": "menu",
       "values": [
         "total_part",
@@ -355,24 +310,20 @@
       "default": "total_part"
     },
     "measures_per_section": {
-      "id": "measures_per_section",
       "type": "number",
       "min": 1,
       "max": 100,
       "default": 8
     },
     "words": {
-      "id": "words",
       "type": "checkbox",
       "default": true
     },
     "credit_words": {
-      "id": "credit_words",
       "type": "checkbox",
       "default": true
     },
     "lyrics": {
-      "id": "lyrics",
       "type": "menu",
       "values": [
         "no",
@@ -385,7 +336,6 @@
   },
   "music_bxml": {
     "edit_mode": {
-      "id": "edit_mode",
       "type": "menu",
       "values": [
         "expert",
@@ -396,7 +346,6 @@
       "default": "read"
     },
     "braille_type": {
-      "id": "braille_type",
       "type": "menu",
       "values": [
         "dot-8",
@@ -405,7 +354,6 @@
       "default": "dot-8"
     },
     "notes_dots": {
-      "id": "notes_dots",
       "type": "menu",
       "values": [
         "8_dots",
@@ -415,22 +363,18 @@
       "default": "6_dots_with_group"
     },
     "ascending_chords": {
-      "id": "ascending_chords",
       "type": "checkbox",
       "default": true
     },
     "fingering": {
-      "id": "fingering",
       "type": "checkbox",
       "default": true
     },
     "clef": {
-      "id": "clef",
       "type": "checkbox",
       "default": true
     },
     "parts": {
-      "id": "parts",
       "type": "menu",
       "values": [
         "name",
@@ -439,24 +383,20 @@
       "default": "name"
     },
     "measure_b123": {
-      "id": "measure_b123",
       "type": "checkbox",
       "default": false
     },
     "measure_number": {
-      "id": "measure_number",
       "type": "checkbox",
       "default": false
     },
     "measure_every": {
-      "id": "measure_every",
       "type": "number",
       "min": 1,
       "max": 100,
       "default": 1
     },
     "view": {
-      "id": "view",
       "type": "menu",
       "values": [
         "by_section",
@@ -465,7 +405,6 @@
       "default": "by_section"
     },
     "section": {
-      "id": "section",
       "type": "menu",
       "values": [
         "total_part",
@@ -475,24 +414,20 @@
       "default": "total_part"
     },
     "measures_per_section": {
-      "id": "measures_per_section",
       "type": "number",
       "min": 1,
       "max": 100,
       "default": 8
     },
     "words": {
-      "id": "words",
       "type": "checkbox",
       "default": true
     },
     "credit_words": {
-      "id": "credit_words",
       "type": "checkbox",
       "default": true
     },
     "lyrics": {
-      "id": "lyrics",
       "type": "menu",
       "values": [
         "no",
@@ -503,35 +438,30 @@
       "default": "no"
     },
     "karaoke": {
-      "id": "karaoke",
       "type": "checkbox",
       "default": true
     }
   },
   "speech": {
     "volume_headphone": {
-      "id": "volume_headphone",
       "type": "number",
       "min": 0,
       "max": 100,
       "default": 50
     },
     "volume_hp": {
-      "id": "volume_hp",
       "type": "number",
       "min": 0,
       "max": 100,
       "default": 50
     },
     "speed": {
-      "id": "speed",
       "type": "number",
       "min": 40,
       "max": 240,
       "default": 100
     },
     "synthesis": {
-      "id": "synthesis",
       "type": "menu",
       "values": [
         "picotts",
@@ -544,14 +474,12 @@
   },
   "radio": {
     "volume_headphone": {
-      "id": "volume_headphone",
       "type": "number",
       "min": 0,
       "max": 100,
       "default": 50
     },
     "volume_hp": {
-      "id": "volume_hp",
       "type": "number",
       "min": 0,
       "max": 100,
@@ -560,7 +488,6 @@
   },
   "agenda": {
     "default_presentation": {
-      "id": "default_presentation",
       "type": "menu",
       "values": [
         "standard",
@@ -571,7 +498,6 @@
       "default": "standard"
     },
     "remember": {
-      "id": "remember",
       "type": "menu",
       "values": [
         "no",
@@ -584,7 +510,6 @@
   },
   "braille_learning": {
     "use_vocal": {
-      "id": "use_vocal",
       "type": "menu",
       "values": [
         "auto",
@@ -594,12 +519,10 @@
       "default": "auto"
     },
     "keep_spaces": {
-      "id": "keep_spaces",
       "type": "checkbox",
       "default": false
     },
     "write_all": {
-      "id": "write_all",
       "type": "checkbox",
       "default": false
     }


### PR DESCRIPTION
This pull request removes the `id` field from all settings in the `src/settings.json` file and updates the corresponding test logic in `src/__tests__/settings.test.js` to reflect this change. The `id` field was deemed redundant and has been removed to simplify the settings structure.

### Changes to settings structure:

* Removed the `id` field from all settings in `src/settings.json`, including settings under categories such as `system`, `bluetooth`, `editor`, `math`, `music_xml`, `music_bxml`, `speech`, `radio`, `agenda`, and `braille_learning`. This affects all setting types, including `menu`, `checkbox`, `number`, and `text`. [[1]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL4) [[2]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL14-L29) [[3]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL39) [[4]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL48) [[5]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL58) [[6]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL68) [[7]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL78) [[8]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL88) [[9]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL98) [[10]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL108) [[11]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL118) [[12]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL128) [[13]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL138) [[14]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL148-L182) [[15]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL191) [[16]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL201-L218) [[17]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL227) [[18]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL236) [[19]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL245-L257) [[20]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL268) [[21]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL279) [[22]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL288) [[23]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL298-L313) [[24]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL322-L339) [[25]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL348) [[26]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL358-L375) [[27]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL388) [[28]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL399) [[29]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL408) [[30]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL418-L433) [[31]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL442-L459) [[32]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL468) [[33]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL478-L495) [[34]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL506-L534) [[35]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL547-L554) [[36]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL563) [[37]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL574) [[38]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL587) [[39]](diffhunk://#diff-77439b31f09e0feb357768dec91579a7c7fdc37b2a417b92fd31aab5e5f3593bL597-L602)

### Updates to test logic:

* Removed the check for the `id` field in the `checkSettingsIntegrity` function within the `describe("unit | Settings")` test suite in `src/__tests__/settings.test.js`. This aligns the test logic with the updated settings structure.