### PR TITLE
[TECH] Delete the script id field

### DIFF
--- a/src/scripts/add-new-setting.js
+++ b/src/scripts/add-new-setting.js
@@ -124,7 +124,6 @@ export class AddNewSetting {
       }
 
       section[this.key] = {
-        id: this.key,
         type: this.type,
         default: this.default,
         ...(this.type === "menu" && { values: this.values }),


### PR DESCRIPTION
This pull request includes a minor change to the `AddNewSetting` class in the `src/scripts/add-new-setting.js` file. The `id` property has been removed from the object assigned to `section[this.key]`.

* [`src/scripts/add-new-setting.js`](diffhunk://#diff-9d0c7b36c2c3961cce7fb4ac366cf17f311f79d60eebd83662ae401dfc2152f1L127): Removed the `id` property from the object assigned to `section[this.key]` in the `AddNewSetting` class.