### PR TITLE
[FEATURE] Use the range type for setting component

### DIFF
--- a/src/__tests__/components/SettingComponent.spec.js
+++ b/src/__tests__/components/SettingComponent.spec.js
@@ -43,14 +43,14 @@ describe("SettingComponent.vue", () => {
     expect(settingsStore.updateSetting).toHaveBeenCalledWith("category", "dropdown", "option2");
   });
 
-  it("renders number input and updates store on change", async () => {
+  it("renders range input and updates store on change", async () => {
     const wrapper = render(SettingComponent, { global: { plugins: [pinia] } }, {
       settingSection: "category",
       settingKey: "number",
       setting: { type: "number", min: 1, max: 10, default: 5 },
     });
 
-    const numberInput = wrapper.find("input[type='number']");
+    const numberInput = wrapper.find("input[type='range']");
     expect(numberInput.exists()).toBe(true);
     await numberInput.setValue(7);
     expect(settingsStore.updateSetting).toHaveBeenCalledWith("category", "number", 7);

--- a/src/components/SettingComponent.vue
+++ b/src/components/SettingComponent.vue
@@ -30,6 +30,9 @@ export default {
   },
   methods: {
     updateSetting() {
+      if (this.setting.type === 'number') {
+        this.settingValue = parseInt(this.settingValue)
+      }
       useSettingsStore().updateSetting(this.settingSection, this.settingKey, this.settingValue);
     },
     setDefault() {
@@ -75,18 +78,25 @@ export default {
     </select>
 
     <!-- Number input -->
-    <input
-      v-else-if="setting.type === 'number'"
-      type="number"
-      :id="label_id"
-      :name="name"
-      :min="setting.min"
-      :max="setting.max"
-      :value="settingValue"
-      @input="updateSetting"
-      v-model="settingValue"
-      class="setting-input"
-    />
+    <div v-else-if="setting.type === 'number'">
+      <input
+        type="range"
+        :id="label_id"
+        :name="name"
+        :min="setting.min"
+        :max="setting.max"
+        :value="settingValue"
+        @input="updateSetting"
+        v-model="settingValue"
+        class="setting-input"
+        :list="label_id+'tickmarks'"
+      />
+      <datalist :id="label_id+'tickmarks'">
+        <option :value="setting.min"></option>
+        <option :value="setting.default"></option>
+        <option :value="setting.max"></option>
+      </datalist>
+    </div>
 
     <!-- Text input -->
     <input


### PR DESCRIPTION
This pull request modifies the `SettingComponent` to replace the `number` input type with a `range` input type for better user experience. It also updates the corresponding test cases and adds a `datalist` for tick marks on the range input.

### Changes to `SettingComponent` functionality:

* Replaced the `number` input type with a `range` input type for settings of type `number`, ensuring a more user-friendly slider interface.
* Added a `datalist` element to provide tick marks for the `range` input, showing the minimum, default, and maximum values.
* Updated the `updateSetting` method to parse the `range` input value as an integer when the setting type is `number`.

### Changes to test cases:

* Updated the test case in `SettingComponent.spec.js` to validate the behavior of the `range` input type instead of the `number` input type.