### PR TITLE
tech: check vitest on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     types:
       - synchronize
       - opened
+  push:
+    branches:
+      - main
 
 jobs:
   eslint:
@@ -29,7 +32,7 @@ jobs:
   vitest:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.pull_request.labels.*.name, 'No deployment') && github.event.pull_request.draft == false"
+    if: "github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'No deployment') && github.event.pull_request.draft == false"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/ci.yml` to include support for `push` events and modifies conditional logic for the `vitest` job. These changes aim to enhance deployment flexibility and ensure tests are triggered appropriately.

Workflow configuration updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR8-R10): Added support for `push` events to trigger workflows on the `main` branch.

Job condition adjustments:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL32-R35): Updated the conditional logic for the `vitest` job to allow execution for `push` events, while maintaining existing conditions for pull requests.