### PR TITLE
fix(workflow): fix the pr title check

### DIFF
--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Validate PR title
         run: |
-          if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^(fix|feat|tech|docs|bump|style|refactor|chore|perf|test|bump|revert):')" ]]; then
+          if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^(fix|feat|tech|docs|bump|style|refactor|chore|perf|test|revert)(\([^)]+\))?:')" ]]; then
             echo "Error: Pull request title must start with [BUGFIX], [TECH], [DOC], [BUMP] or [FEATURE]."
             exit 1
           fi


### PR DESCRIPTION
This pull request updates the PR title validation logic in the GitHub Actions workflow to enforce a more specific format for pull request titles.

* **Validation logic update**: Modified the regular expression in the `Validate PR title` step of `.github/workflows/PR Title Check.yml` to allow optional scope definitions in parentheses after the type (e.g., `feat(scope):`). This enforces a more standardized and descriptive PR title format.