### PR TITLE
fix(app): display the link to download last version only if is available

### DIFF
--- a/src/views/DownloadPageView.vue
+++ b/src/views/DownloadPageView.vue
@@ -70,7 +70,11 @@ export default {
         <a :href="links.theotime.github" target="_blank" class="download-link">{{$t('download.message-3-1')}}</a>
         {{$t('download.message-3-2')}}
       </p>
-      <a class="download-link" :href="last_version['file']">
+      <a
+        v-if="last_version['file']"
+        class="download-link"
+        :href="last_version['file']"
+      >
         {{$t('download.downloadOtherLast', {version: last_version['tag']})}}
       </a>
       <a class="download-link" :href="links.theotime.releases" target="_blank">


### PR DESCRIPTION
This pull request includes a small update to the `DownloadPageView.vue` file, improving the conditional rendering of the download link for the last version.

* [`src/views/DownloadPageView.vue`](diffhunk://#diff-611b70bedce12a6cbc6642e1de902ec1aca842de0f9222a98dd630165d90747cL73-R77): Added a `v-if` condition to ensure the download link for the last version is only rendered if `last_version['file']` exists.