### PR TITLE
tech(workflow): add a workflow to block fixup commits

### DIFF
--- a/.github/workflows/commits-check.yaml
+++ b/.github/workflows/commits-check.yaml
@@ -1,0 +1,15 @@
+name: commits check
+
+on:
+  pull_request:
+
+jobs:
+  block-autosquash-commits:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Block Autosquash Commits
+        uses: xt0rted/block-autosquash-commits-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce commit standards by blocking autosquash commits in pull requests.

Workflow addition:

* [`.github/workflows/commits-check.yaml`](diffhunk://#diff-f638afde9f4abd99413459359a4a2d2e915346e83c42d4064655e739d0aacdbaR1-R15): Added a new workflow named `commits check`, which uses the `block-autosquash-commits-action` to prevent autosquash commits in pull requests.