### PR TITLE
tech(workflow): remove release_type from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,10 @@
 # This workflow generates a new version and pushes it to the main branch
 # It runs manually
 
-name: "Build version"
+name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      release_type:
-        description: "The type of release to generate"
-        required: true
-        default: "patch"
 
 permissions:
   contents: write
@@ -19,13 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if input is valid
-        run: |
-          if [[ "${{ github.event.inputs.release_type }}" != "major" && "${{ github.event.inputs.release_type }}" != "minor" && "${{ github.event.inputs.release_type }}" != "patch" ]]; then
-            echo "Invalid release type. Please use 'major', 'minor' or 'patch'."
-            exit 1
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -51,7 +39,7 @@ jobs:
 
       - name: Build new version
         # Use standard-version to generate a new version
-        run: npm run release -- --release-as ${{ github.event.inputs.release_type }}
+        run: npm run release
 
       - name: Push new version
         run: git push --follow-tags origin main


### PR DESCRIPTION
This pull request simplifies the release workflow by removing unnecessary inputs and validation checks, and renaming the workflow file for clarity. The changes streamline the process of generating and pushing new versions.

Workflow simplification:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-L12): Removed the `release_type` input and its validation logic, simplifying the workflow configuration. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-L12) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-L28)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R42): Updated the `npm run release` command to no longer depend on the `release_type` input.

File renaming for clarity:

* `.github/workflows/build-version.yml` → `.github/workflows/release.yml`: Renamed the workflow file to better reflect its purpose.