### PR TITLE
tech: open website when start project

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,9 @@ export default defineConfig(({ mode }) => {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
     },
+    server: {
+      open: true,
+    },
   };
   if (mode === "production") {
     sendLog({


### PR DESCRIPTION
This pull request makes a small configuration change to the `vite.config.js` file. It adds a `server` option to automatically open the browser when the development server starts.