### PR TITLE
docs: fix the readme link for goto contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Npm run build
 In the past, this project used tailwindcss. However, its use has been removed. A main style sheet is available, and you can enrich it from the components directly.
 
 ## Contributing
-You can read the [Contribution guide](Contribution guide.md) file to learn how to contribute to the project.
+You can read the [Contribution guide](https://github.com/theotime2005/bnote-settings/blob/main/Contribution%20guide.md) file to learn how to contribute to the project.
 
 ## Discord Server
 You can join the [Discord server](https://discord.gg/ThGqydYJ) to discuss the project. You can also ask for help or propose new features and receive notifications about the project.


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change updates the link to the contribution guide to point to the correct URL on GitHub.