### PR TITLE
fix(views) use correctly the notification toster

### DIFF
--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,5 +1,6 @@
 <script>
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
+import NotificationToast from "@/components/NotificationToast.vue";
 import SettingComponent from "@/components/SettingComponent.vue";
 import UploadFileComponent from "@/components/UploadFileComponent.vue";
 import { useNotifications } from "@/composables/useNotifications.js";
@@ -9,6 +10,7 @@ import { useSettingsStore } from "@/stores/settingsStore.js";
 export default {
   name: "SettingsView",
   components: {
+    NotificationToast,
     UploadFileComponent,
     SettingComponent,
     LoadingSpinner,
@@ -275,7 +277,7 @@ export default {
     </div>
 
     <!-- Notifications -->
-    <div v-for="notification in notifications.notifications.value" :key="notification.id">
+    <div v-for="notification in notifications.notifications" :key="notification.id">
       <NotificationToast
         :visible="notification.visible"
         :type="notification.type"


### PR DESCRIPTION
This pull request enhances the `SettingsView` by integrating a new `NotificationToast` component and streamlining the notification rendering logic. The most important changes are summarized below:

### Integration of `NotificationToast` Component:

* Added `NotificationToast` to the imports in `src/views/SettingsView.vue` and registered it as a component to enable its usage within the `SettingsView`. [[1]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6R3) [[2]](diffhunk://#diff-5e0b544f4313686d1db89dd68b558c482d800208982757006c2700ae33437fb6R13)

### Notification Rendering Improvements:

* Updated the `v-for` directive to directly iterate over `notifications.notifications` instead of `notifications.notifications.value`, simplifying the rendering logic for notifications.