### PR TITLE
tech(linter): Add linter rule for vue components

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,12 @@ export default [
       "no-trailing-spaces": ["error"],
       "no-multi-spaces": ["error"],
       "func-style": ["error", "declaration", { "allowArrowFunctions": false }],
+      "vue/block-order": [
+        "error",
+        {
+          order: ["script", "template", "style"],
+        },
+      ],
     },
   },
   {

--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -1,10 +1,3 @@
-<template>
-  <div class="loading-spinner" :class="{ 'loading-spinner--small': size === 'small', 'loading-spinner--large': size === 'large' }">
-    <div class="loading-spinner__circle"></div>
-    <span v-if="text" class="loading-spinner__text">{{ text }}</span>
-  </div>
-</template>
-
 <script>
 export default {
   name: "LoadingSpinner",
@@ -21,6 +14,13 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="loading-spinner" :class="{ 'loading-spinner--small': size === 'small', 'loading-spinner--large': size === 'large' }">
+    <div class="loading-spinner__circle"></div>
+    <span v-if="text" class="loading-spinner__text">{{ text }}</span>
+  </div>
+</template>
 
 <style scoped>
 .loading-spinner {

--- a/src/components/NotificationToast.vue
+++ b/src/components/NotificationToast.vue
@@ -1,33 +1,3 @@
-<template>
-  <Teleport to="body">
-    <Transition name="toast" appear>
-      <div
-        v-if="visible"
-        class="toast"
-        :class="[`toast--${type}`, { 'toast--dismissible': dismissible }]"
-        role="alert"
-        :aria-live="type === 'error' ? 'assertive' : 'polite'"
-      >
-        <div class="toast__icon">
-          <component :is="iconComponent" />
-        </div>
-        <div class="toast__content">
-          <h4 v-if="title" class="toast__title">{{ title }}</h4>
-          <p class="toast__message">{{ message }}</p>
-        </div>
-        <button
-          v-if="dismissible"
-          class="toast__close"
-          :aria-label="$t('common.close')"
-          @click="$emit('close')"
-        >
-          ×
-        </button>
-      </div>
-    </Transition>
-  </Teleport>
-</template>
-
 <script>
 export default {
   name: "NotificationToast",
@@ -79,6 +49,36 @@ export default {
   },
 };
 </script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="toast" appear>
+      <div
+        v-if="visible"
+        class="toast"
+        :class="[`toast--${type}`, { 'toast--dismissible': dismissible }]"
+        role="alert"
+        :aria-live="type === 'error' ? 'assertive' : 'polite'"
+      >
+        <div class="toast__icon">
+          <component :is="iconComponent" />
+        </div>
+        <div class="toast__content">
+          <h4 v-if="title" class="toast__title">{{ title }}</h4>
+          <p class="toast__message">{{ message }}</p>
+        </div>
+        <button
+          v-if="dismissible"
+          class="toast__close"
+          :aria-label="$t('common.close')"
+          @click="$emit('close')"
+        >
+          ×
+        </button>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
 
 <style scoped>
 .toast {


### PR DESCRIPTION
This pull request introduces a new ESLint rule for Vue block order and reorganizes the structure of Vue component files by moving `<template>` sections below `<script>` sections to align with the new rule. The most important changes include the addition of the ESLint rule and the restructuring of the `LoadingSpinner` and `NotificationToast` components.

### ESLint Configuration Update:
* Added the `"vue/block-order"` rule to enforce the order of blocks in Vue single-file components (`<script>`, `<template>`, `<style>`).

### Component File Restructuring:
* Moved the `<template>` section below the `<script>` section in the `LoadingSpinner.vue` component to comply with the new block order rule. [[1]](diffhunk://#diff-0addca6bd97c644599546dc23f2f1b8dff03a96d23d1c582056a58de102cfa67L1-L7) [[2]](diffhunk://#diff-0addca6bd97c644599546dc23f2f1b8dff03a96d23d1c582056a58de102cfa67R18-R24)
* Moved the `<template>` section below the `<script>` section in the `NotificationToast.vue` component to comply with the new block order rule. [[1]](diffhunk://#diff-7765761dab6c238a3d7b6b5db79875a212956ecf6689f5b76293f5f772b74e70L1-L30) [[2]](diffhunk://#diff-7765761dab6c238a3d7b6b5db79875a212956ecf6689f5b76293f5f772b74e70R53-R82)