### PR TITLE
tech(dependabot): add the nvm on packages to fetch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,14 @@ updates:
     commit-message:
       prefix: bump
       include: scope
+
+  # fetch and update latest nvm packages
+  - package-ecosystem: nvm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '00:00'
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: bump
+      include: scope


### PR DESCRIPTION
This pull request updates the Dependabot configuration to include support for managing `nvm` packages. The change ensures that the latest `nvm` packages are fetched and updated daily.

### Dependabot configuration changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R30-R40): Added a new configuration for the `nvm` package ecosystem, scheduling daily updates at midnight, with a limit of 3 open pull requests. The commit message format includes a `bump` prefix and scope.