### PR TITLE
tech: include i18n file in test render

### DIFF
--- a/src/tests/components/FooterComponent.spec.js
+++ b/src/tests/components/FooterComponent.spec.js
@@ -1,17 +1,9 @@
 import FooterComponent from "@/components/FooterComponent.vue";
-import i18n from "@/i18n.js";
 import { render, t } from "@/tests/components/helpers.js";
-
-
-
-
 
 describe("FooterComponent", () => {
   it("renders footer messages correctly", () => {
     const wrapper = render(FooterComponent, {
-      mocks: {
-        $i18n: i18n,
-      },
     });
     expect(wrapper.text()).toContain(t("footer.message1"));
     expect(wrapper.text()).toContain(t("footer.message2"));
@@ -19,18 +11,12 @@ describe("FooterComponent", () => {
 
   it("renders the version info", () => {
     const wrapper = render(FooterComponent, {
-      mocks: {
-        $i18n: i18n,
-      },
     });
     expect(wrapper.text()).toContain(t("footer.version"));
   });
 
   it("renders the GitHub link correctly", () => {
     const wrapper = render(FooterComponent, {
-      mocks: {
-        $i18n: i18n,
-      },
     });
     const link = wrapper.find("a");
     expect(link.attributes("href")).toBe("https://github.com/theotime2005/bnote-settings");
@@ -39,9 +25,6 @@ describe("FooterComponent", () => {
 
   it("contains LanguageComponent", () => {
     const wrapper = render(FooterComponent, {
-      mocks: {
-        $i18n: i18n,
-      },
     });
     expect(wrapper.findComponent({ name: "LanguageComponent" }).exists()).toBe(true);
   });

--- a/src/tests/components/helpers.js
+++ b/src/tests/components/helpers.js
@@ -1,6 +1,8 @@
 import { mount } from "@vue/test-utils";
 import { vi } from "vitest";
 
+import i18n from "@/i18n.js";
+
 // Mock global pour les composables
 vi.mock("@/composables/useNotifications.js", () => ({
   useNotifications: () => ({
@@ -23,6 +25,7 @@ function render(component, global = {}, properties = {}, data = null) {
   // Initialize mocks with the default $t mock
   const defaultMocks = {
     $t: (msg) => msg,
+    $i18n: i18n,
   };
 
   // Fusion of the global options with the default mocks


### PR DESCRIPTION
## Problem

Today; the render include just the function t for legacy api. If using composition api, we must include manualy i18n in the tests.

## Solution

Include i18n in render to migrate all vue components in composition api.

## Note

We can removing the i18n mock in the footer test

## Test
Check that all tests past.
