### PR TITLE
fix(workflow): check title when pr is synchronised

### DIFF
--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -2,7 +2,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened] # Correction ici
+    types: [opened, reopened, synchronize]
     branches:
       - main
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for pull request title checks to ensure the workflow triggers on more pull request events.

Workflow trigger improvements:

* [`.github/workflows/PR Title Check.yml`](diffhunk://#diff-e6d2be8389bd688a7879afcde237f873c599b6d1fe794a6a4352e4a428192e93L5-R5): The workflow is now triggered on `open`, `reopened`, and `synchronize` pull request events instead of just `opened`, ensuring title checks run in more scenarios.