### PR TITLE
refactor: migrate the App file to composition api

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,57 +1,53 @@
-<script>
+<script setup>
+import { onBeforeMount, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
 import FooterComponent from "@/components/FooterComponent.vue";
 import NavBarComponent from "@/components/NavBarComponent.vue";
+import i18n from "@/i18n.js";
 import { useLocaleCookie } from "@/scripts/useLocaleCookie.js";
 
-export default {
-  components: {
-    FooterComponent,
-    NavBarComponent,
-  },
-  data() {
-    return {
-      mainRef: null,
-      hasLanguage: false,
-      canReset: false,
-    };
-  },
+const mainRef = ref(null);
+const hasLanguage = ref(false);
+const canReset = ref(false);
 
-  beforeMount() {
-    // set locale from cookie
-    const localeCookie = useLocaleCookie.getLocaleCookie();
-    if (localeCookie) {
-      this.$i18n.locale = localeCookie;
-      this.hasLanguage = true;
-    } else if (import.meta.env.MODE === "test") {
-      this.hasLanguage = true;
-    }
-    // Toggle the reset cookies variable
-    if (import.meta.env.MODE === "development") {
-      this.canReset = true;
-    }
-  },
+onBeforeMount(() => {
+  // set locale from cookie
+  const localeCookie = useLocaleCookie.getLocaleCookie();
+  if (localeCookie) {
+    i18n.global.locale = localeCookie;
+    hasLanguage.value = true;
+  } else if (import.meta.env.MODE === "test") {
+    hasLanguage.value = true;
+  }
+  // Toggle the reset cookies variable
+  if (import.meta.env.MODE === "development") {
+    canReset.value = true;
+  }
+});
 
-  methods: {
-    focusMain() {
-      if (this.$refs.mainRef) {
-        this.$refs.mainRef.focus();
-      }
-    },
+function focusMain() {
+  if (mainRef.value) {
+    mainRef.value.focus();
+  }
+}
 
-    setLocale(locale) {
-      this.$i18n.locale = locale;
-      useLocaleCookie.setLocaleCookie(locale);
-      this.hasLanguage = true;
-      this.$router.push(this.$route.path);
-    },
+function setLocale(locale) {
+  i18n.global.locale = locale;
+  useLocaleCookie.setLocaleCookie(locale);
+  hasLanguage.value = true;
+  const router = useRouter();
+  const route = useRoute();
+  router.push(route.path);
+}
 
-    resetCookies() {
-      useLocaleCookie.removeCookie();
-      this.hasLanguage = false;
-      this.$router.push(this.$route.path);
-    },
-  },
-};
+function resetCookies() {
+  useLocaleCookie.removeCookie();
+  hasLanguage.value = false;
+  const route = useRoute();
+  const router = useRouter();
+  router.push(route.path);
+}
 </script>
 
 <template>
@@ -69,7 +65,7 @@ export default {
       <h1>Select your language</h1>
       <div class="divider"></div>
       <ul class="flex gap-4 justify-between mt-4 mb-4">
-        <li v-for="locale in $i18n.availableLocales" :key="locale">
+        <li v-for="locale in i18n.global.availableLocales" :key="locale">
           <button class="custom-button button-blue" @click="setLocale(locale)">
             {{ locale }}
           </button>


### PR DESCRIPTION
This pull request refactors the main `App.vue` component to use the `<script setup>` syntax and Vue 3 Composition API features, resulting in a more modern and concise codebase. The changes also update how localization and routing are handled, making the component more idiomatic for Vue 3 projects.

**Refactor to Composition API and `<script setup>`:**

* Converted the component from Options API to Composition API using `<script setup>`, replacing `data`, `methods`, and lifecycle hooks with `ref` variables and composition functions.
* Updated event handlers and reactive state (`mainRef`, `hasLanguage`, `canReset`) to use `ref` and standard functions instead of methods.

**Localization and routing improvements:**

* Replaced usage of `this.$i18n` and `this.$router` with direct imports of `i18n`, `useRouter`, and `useRoute`, updating all references accordingly.
* Changed the language selection dropdown to use `i18n.global.availableLocales` instead of `$i18n.availableLocales`.

These updates modernize the component and align it with current Vue 3 best practices.