### PR TITLE
fix(workflow): include 'breaking' keyword in PR title validation

### DIFF
--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Validate PR title
         run: |
-          if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^(fix|feat|tech|docs|bump|style|refactor|chore|perf|test|revert)(\([^)]+\))?:')" ]]; then
-            echo "Error: Pull request title must start with one of the following keywords: fix, feat, tech, docs, bump, style, refactor, chore, perf, test, or revert. Optionally, it can include a scope in parentheses followed by a colon (e.g., 'feat(scope):')."
+          if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^(fix|feat|tech|docs|bump|style|refactor|chore|perf|test|revert|breaking)(\([^)]+\))?:')" ]]; then
+            echo "Error: Pull request title must start with one of the following keywords: fix, feat, tech, docs, bump, style, refactor, chore, perf, test, breaking or revert. Optionally, it can include a scope in parentheses followed by a colon (e.g., 'feat(scope):')."
             exit 1
           fi

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,6 +1,10 @@
 {
   "types": [
     {
+      "type": "breaking",
+      "section": "💥 Breaking changes"
+    },
+    {
       "type": "feat",
       "section": "🚀 New features"
     },


### PR DESCRIPTION
This pull request makes a minor update to the pull request title validation workflow. The change adds "breaking" as an allowed keyword for PR titles, ensuring that PRs introducing breaking changes can be properly labeled and pass the title check. 

* Added "breaking" to the list of valid prefixes for pull request titles in the `.github/workflows/PR Title Check.yml` validation script.