### PR TITLE
feat: migrate components to use composition API and update i18n integration

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { onBeforeMount, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 
 import FooterComponent from "@/components/FooterComponent.vue";
 import NavBarComponent from "@/components/NavBarComponent.vue";
-import i18n from "@/i18n.js";
 import { useLocaleCookie } from "@/scripts/useLocaleCookie.js";
 
+const { locale, availableLocales } = useI18n();
 const mainRef = ref(null);
 const hasLanguage = ref(false);
 const canReset = ref(false);
@@ -15,7 +16,7 @@ onBeforeMount(() => {
   // set locale from cookie
   const localeCookie = useLocaleCookie.getLocaleCookie();
   if (localeCookie) {
-    i18n.global.locale = localeCookie;
+    locale.value = localeCookie;
     hasLanguage.value = true;
   } else if (import.meta.env.MODE === "test") {
     hasLanguage.value = true;
@@ -32,9 +33,9 @@ function focusMain() {
   }
 }
 
-function setLocale(locale) {
-  i18n.global.locale = locale;
-  useLocaleCookie.setLocaleCookie(locale);
+function setLocale(newLocale) {
+  locale.value = newLocale;
+  useLocaleCookie.setLocaleCookie(newLocale);
   hasLanguage.value = true;
   const router = useRouter();
   const route = useRoute();
@@ -65,9 +66,9 @@ function resetCookies() {
       <h1>Select your language</h1>
       <div class="divider"></div>
       <ul class="flex gap-4 justify-between mt-4 mb-4">
-        <li v-for="locale in i18n.global.availableLocales" :key="locale">
-          <button class="custom-button button-blue" @click="setLocale(locale)">
-            {{ locale }}
+        <li v-for="language in availableLocales" :key="language">
+          <button class="custom-button button-blue" @click="setLocale(language)">
+            {{ language }}
           </button>
         </li>
       </ul>

--- a/src/components/FooterComponent.vue
+++ b/src/components/FooterComponent.vue
@@ -1,24 +1,21 @@
 <script setup>
-import { useI18n } from "vue-i18n";
-
 import LanguageComponent from "@/components/LanguageComponent.vue";
 
 import packageInfo from "../../package.json";
 
-const { t } = useI18n();
 </script>
 
 <template>
-  <footer class="footer-container" :aria-label="t('footer.label')">
+  <footer class="footer-container" :aria-label="$t('footer.label')">
     <div class="footer-content">
       <div class="footer-messages">
-        <p>{{ t('footer.message1') }}</p>
-        <p>{{ t('footer.message2') }}</p>
+        <p>{{ $t('footer.message1') }}</p>
+        <p>{{ $t('footer.message2') }}</p>
       </div>
     </div>
     <LanguageComponent />
-    <a class="footer-link" href="https://github.com/theotime2005/bnote-settings">{{ t('footer.code') }}</a>
-    <p>{{ t('footer.version', {version: packageInfo.version}) }}</p>
+    <a class="footer-link" href="https://github.com/theotime2005/bnote-settings">{{ $t('footer.code') }}</a>
+    <p>{{ $t('footer.version', {version: packageInfo.version}) }}</p>
   </footer>
 </template>
 

--- a/src/components/LanguageComponent.vue
+++ b/src/components/LanguageComponent.vue
@@ -2,15 +2,13 @@
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 
-import i18n from "@/i18n.js";
 import { useLocaleCookie } from "@/scripts/useLocaleCookie.js";
 
-const { t } = useI18n();
-const current_language = ref(i18n.global.locale);
-const availableLocales = ref(i18n.global.availableLocales);
+const { t, locale, availableLocales } = useI18n();
+const current_language = ref(locale.value);
 
 function changeLanguage() {
-  i18n.global.locale = current_language.value;
+  locale.value = current_language.value;
   document.documentElement.lang = current_language.value;
   useLocaleCookie.setLocaleCookie(current_language.value);
 }

--- a/src/components/SettingComponent.vue
+++ b/src/components/SettingComponent.vue
@@ -85,7 +85,7 @@ function setDefault() {
           :key="option"
           :value="option"
         >
-          {{ !props.setting.isTranslate ? t(`settings.values.${option}`) : option }}
+          {{ !props.setting.isTranslate ? $t(`settings.values.${option}`) : option }}
         </option>
       </select>
     </div>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -6,7 +6,9 @@ import fr from "../locales/fr.json";
 import it from "../locales/it.json";
 
 const i18n = createI18n({
+  legacy: false,
   locale: "fr",
+  fallbackLocale: "en",
   messages: {
     fr,
     en,

--- a/src/views/FaqView.vue
+++ b/src/views/FaqView.vue
@@ -1,36 +1,45 @@
-<script setup>
-import { onMounted, ref, watch } from "vue";
-import { useI18n } from "vue-i18n";
-
+<script>
 import { sendLog } from "@/scripts/send-log-message-script.js";
 
-const { t, locale } = useI18n();
-const faq = ref(null);
-
-async function loadFaq() {
-  faq.value = null;
-  const fileName = `faq/${locale.value}.json`;
-  try {
-    const request = await fetch(fileName);
-    if (request.ok) {
-      faq.value = await request.json();
-    }
-  } catch (e) {
-    sendLog({ fileName: "FaqView", functionName: "loadFaq", type: "error", log: e });
-  }
-}
-
-watch(locale, loadFaq, { immediate: true });
-
-onMounted(() => {
-  loadFaq();
-});
+export default {
+  name: "FaqView",
+  data() {
+    return {
+      faq: null,
+    };
+  },
+  watch: {
+    "$i18n.locale": {
+      immediate: true,
+      handler() {
+        this.loadFaq();
+      },
+    },
+  },
+  mounted() {
+    this.loadFaq();
+  },
+  methods: {
+    async loadFaq() {
+      this.faq = null;
+      const file_name = `faq/${this.$i18n.locale}.json`;
+      try {
+        const request = await fetch(file_name);
+        if (request.ok) {
+          this.faq = await request.json();
+        }
+      } catch (e) {
+        sendLog({ fileName: "FaqView", functionName: "loadFaq", type: "error", log: e });
+      }
+    },
+  },
+};
 </script>
 
 <template>
   <div class="faq-container">
-    <h1 class="faq-title">{{ t('faq.title') }}</h1>
-    <p class="faq-presentation">{{ t('faq.presentation') }}</p>
+    <h1 class="faq-title">{{ $t('faq.title') }}</h1>
+    <p class="faq-presentation">{{ $t('faq.presentation') }}</p>
 
     <div v-if="faq && faq.length">
       <article
@@ -59,7 +68,7 @@ v-for="(subElement, subElemIndex) in element"
       </article>
     </div>
 
-    <p v-else class="faq-empty">{{ t('faq.nofaq') }}</p>
+    <p v-else class="faq-empty">{{ $t('faq.nofaq') }}</p>
   </div>
 </template>
 


### PR DESCRIPTION
This pull request refactors the application's internationalization (i18n) integration to use the Composition API from `vue-i18n` more consistently throughout the codebase. It simplifies locale management, removes direct imports of the `i18n` instance in favor of the `useI18n` hook, and updates template translation calls to use the `$t` shortcut. Additionally, it improves reactivity and maintainability in language selection and FAQ loading.

**Internationalization (i18n) Refactoring:**

* Replaced direct usage of the `i18n` instance with the `useI18n` Composition API in `App.vue` and `LanguageComponent.vue`, making locale and available locales reactive and simplifying locale changes. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R3-R10) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L18-R19) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L35-R38) [[4]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L68-R71) [[5]](diffhunk://#diff-e4549888235201835af39686be6a12f253ad3cf5a47d20d5040a6e2d90779e43L5-R11)
* Updated the i18n configuration in `src/i18n.js` to enable Composition API mode (`legacy: false`) and set a fallback locale to English.

**Template and Translation Usage Updates:**

* Changed all translation calls in templates to use the `$t` shortcut instead of destructured `t` from `useI18n`, affecting `FooterComponent.vue`, `SettingComponent.vue`, and `FaqView.vue`. [[1]](diffhunk://#diff-7490b18034c0e87a348ce68c97884563c04d5fbe2ff5f42a85dc927ff0ce5f94L2-R18) [[2]](diffhunk://#diff-4b510c76d34984739ba35e177e172004533c9000a381ecd3963ab3b20b28b851L88-R88) [[3]](diffhunk://#diff-5db7ce3b98b31cfb36415a5bd4dddf9bd22e3070c9b7f3ab40d2fefe61dc99b9L1-R42) [[4]](diffhunk://#diff-5db7ce3b98b31cfb36415a5bd4dddf9bd22e3070c9b7f3ab40d2fefe61dc99b9L62-R71)

**FAQ View Improvements:**

* Refactored `FaqView.vue` from `<script setup>` to the Options API to improve reactivity with locale changes, ensuring the FAQ reloads when the language changes. [[1]](diffhunk://#diff-5db7ce3b98b31cfb36415a5bd4dddf9bd22e3070c9b7f3ab40d2fefe61dc99b9L1-R42) [[2]](diffhunk://#diff-5db7ce3b98b31cfb36415a5bd4dddf9bd22e3070c9b7f3ab40d2fefe61dc99b9L62-R71)