### PR TITLE
feat(a11y): global scaffold (skip link, lang sync, route announcements) and accessible language selection UI with high-contrast styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta name="google-site-verification" content="HWlT_6pqqqCebAbwZ14UfYiNST45zFc0U_EdQadtbvU" />
   </head>
   <body>
+    <a href="#main-content" class="skip-link">Aller au contenu principal</a>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     <meta name="google-site-verification" content="HWlT_6pqqqCebAbwZ14UfYiNST45zFc0U_EdQadtbvU" />
   </head>
   <body>
-    <a href="#main-content" class="skip-link">Aller au contenu principal</a>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1575,45 +1575,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
-      "integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@vue/shared": "3.5.21",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
-      "integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.21",
-        "@vue/shared": "3.5.21"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
-      "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/shared": "3.5.21"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
-      "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
-      "license": "MIT"
-    },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.21",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
@@ -7174,23 +7135,6 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
-    },
-    "node_modules/vue/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.20",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.20.tgz",
-      "integrity": "sha512-SFcxapQc0/feWiSBfkGsa1v4DOrnMAQSYuvDMpEaxbpH5dKbnEM5KobSNSgU+1MbHCl+9ftm7oQWxvwDB6iBfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@vue/compiler-core": "3.5.20",
-        "@vue/compiler-dom": "3.5.20",
-        "@vue/compiler-ssr": "3.5.20",
-        "@vue/shared": "3.5.20",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -95,18 +95,18 @@ function resetCookies() {
       <h1 id="language-title">Select your language</h1>
       <p id="language-desc">Choose your preferred language for the interface.</p>
       <div class="divider"></div>
-      <form @submit.prevent="confirmLanguage" class="mt-4" aria-labelledby="language-title" aria-describedby="language-desc">
+      <form class="mt-4" aria-labelledby="language-title" aria-describedby="language-desc" @submit.prevent="confirmLanguage">
         <fieldset>
           <legend class="form-label">Available languages</legend>
           <ul class="language-grid mt-4 mb-4" role="radiogroup" aria-label="Languages">
             <li v-for="language in availableLocales" :key="language">
               <input
                 class="sr-only"
-                type="radio"
                 :id="`lang-${language}`"
+                type="radio"
                 name="language"
-                :value="language"
                 v-model="selectedLanguage"
+                :value="language"
               />
               <label class="radio-card" :for="`lang-${language}`">
                 <span class="radio-title">{{ languageLabels[language] || language }}</span>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onBeforeMount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeMount, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 
@@ -36,21 +36,10 @@ onBeforeMount(() => {
   }
 });
 
-onMounted(() => {
-  // Sync html lang with current locale
-  if (locale.value) {
-    document.documentElement.setAttribute("lang", locale.value);
-  }
-});
-
-// Update html lang and announcement when locale changes
-watch(() => locale.value, (newLocale) => {
-  if (newLocale) {
-    document.documentElement.setAttribute("lang", newLocale);
-    // Re-announce current page title in new language
-    const route = useRoute();
-    routeAnnouncement.value = t(`${route.name}.title`);
-  }
+// Re-announce current page title when locale changes (html lang is handled elsewhere)
+watch(() => locale.value, () => {
+  const route = useRoute();
+  routeAnnouncement.value = t(`${route.name}.title`);
 });
 
 // Announce route changes for screen readers
@@ -91,6 +80,7 @@ function resetCookies() {
 
 <template>
   <div v-if="hasLanguage">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <NavBarComponent @move-cursor="focusMain" />
     <div aria-live="polite" aria-atomic="true" class="sr-only">{{ routeAnnouncement }}</div>
     <div class="container">

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,8 +102,8 @@ function resetCookies() {
             <li v-for="language in availableLocales" :key="language">
               <input
                 :id="`lang-${language}`"
-                class="sr-only"
                 v-model="selectedLanguage"
+                class="sr-only"
                 type="radio"
                 name="language"
                 :value="language"

--- a/src/App.vue
+++ b/src/App.vue
@@ -115,7 +115,7 @@ function resetCookies() {
             </li>
           </ul>
         </fieldset>
-        <div class="flex justify-between items-center">
+        <div class="flex justify-between items-center language-actions">
           <button type="submit" class="custom-button button-blue" :disabled="!selectedLanguage">Continue</button>
         </div>
       </form>

--- a/src/App.vue
+++ b/src/App.vue
@@ -103,8 +103,8 @@ function resetCookies() {
               <input
                 :id="`lang-${language}`"
                 class="sr-only"
-                type="radio"
                 v-model="selectedLanguage"
+                type="radio"
                 name="language"
                 :value="language"
               />

--- a/src/App.vue
+++ b/src/App.vue
@@ -101,11 +101,11 @@ function resetCookies() {
           <ul class="language-grid mt-4 mb-4" role="radiogroup" aria-label="Languages">
             <li v-for="language in availableLocales" :key="language">
               <input
-                class="sr-only"
                 :id="`lang-${language}`"
+                class="sr-only"
                 type="radio"
-                name="language"
                 v-model="selectedLanguage"
+                name="language"
                 :value="language"
               />
               <label class="radio-card" :for="`lang-${language}`">

--- a/src/components/NavBarComponent.vue
+++ b/src/components/NavBarComponent.vue
@@ -422,7 +422,7 @@ onBeforeUnmount(() => {
 .accessibility-menu {
   position: absolute;
   top: 100%;
-  right: 0;
+  right: -10px;
   margin-top: 0.5rem;
   background: var(--color-white);
   border: 2px solid var(--color-gray-300);

--- a/src/components/NavBarComponent.vue
+++ b/src/components/NavBarComponent.vue
@@ -424,15 +424,19 @@ onBeforeUnmount(() => {
   top: 100%;
   right: 0;
   margin-top: 0.5rem;
-  background: var(--color-white) !important;
-  border: 2px solid var(--color-gray-300);
+  background: #ffffff !important;
+  border: 2px solid #d1d5db;
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-xl);
   padding: var(--space-4);
   width: 300px;
   z-index: 9999;
   transform: translateX(calc(100% - 44px));
-  color: var(--color-gray-900) !important;
+  color: #111827 !important;
+}
+
+.accessibility-menu * {
+  color: #111827 !important;
 }
 
 .accessibility-section {
@@ -446,9 +450,9 @@ onBeforeUnmount(() => {
 .accessibility-title {
   font-size: 1rem;
   font-weight: 700;
-  color: var(--color-gray-900) !important;
+  color: #111827 !important;
   margin-bottom: var(--space-3);
-  border-bottom: 1px solid var(--color-gray-200);
+  border-bottom: 1px solid #e5e7eb;
   padding-bottom: var(--space-2);
 }
 
@@ -488,15 +492,23 @@ onBeforeUnmount(() => {
 
 .accessibility-option span {
   font-weight: 500;
-  color: var(--color-gray-900) !important;
+  color: #111827 !important;
 }
 
 .accessibility-option:hover span {
-  color: var(--color-gray-900) !important;
+  color: #111827 !important;
 }
 
 .accessibility-option:focus-within span {
-  color: var(--color-gray-900) !important;
+  color: #111827 !important;
+}
+
+.accessibility-option label {
+  color: #111827 !important;
+}
+
+.accessibility-option label span {
+  color: #111827 !important;
 }
 
 .main-nav {

--- a/src/components/NavBarComponent.vue
+++ b/src/components/NavBarComponent.vue
@@ -424,7 +424,7 @@ onBeforeUnmount(() => {
   top: 100%;
   right: 0;
   margin-top: 0.5rem;
-  background: var(--color-white);
+  background: var(--color-white) !important;
   border: 2px solid var(--color-gray-300);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-xl);
@@ -432,6 +432,7 @@ onBeforeUnmount(() => {
   width: 300px;
   z-index: 9999;
   transform: translateX(calc(100% - 44px));
+  color: var(--color-gray-900) !important;
 }
 
 .accessibility-section {
@@ -445,7 +446,7 @@ onBeforeUnmount(() => {
 .accessibility-title {
   font-size: 1rem;
   font-weight: 700;
-  color: var(--color-gray-900);
+  color: var(--color-gray-900) !important;
   margin-bottom: var(--space-3);
   border-bottom: 1px solid var(--color-gray-200);
   padding-bottom: var(--space-2);
@@ -486,7 +487,7 @@ onBeforeUnmount(() => {
 
 .accessibility-option span {
   font-weight: 500;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900) !important;
 }
 
 .main-nav {

--- a/src/components/NavBarComponent.vue
+++ b/src/components/NavBarComponent.vue
@@ -109,8 +109,16 @@ function handleKeyDown(event) {
   }
 }
 
+function handleClickOutside(event) {
+  const accessibilityControls = event.target.closest(".accessibility-controls");
+  if (!accessibilityControls && showAccessibilityMenu.value) {
+    showAccessibilityMenu.value = false;
+  }
+}
+
 onMounted(() => {
   window.addEventListener("resize", handleResize);
+  document.addEventListener("click", handleClickOutside);
   handleResize();
   loadAccessibilitySettings();
   applyAccessibilitySettings();
@@ -118,6 +126,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener("resize", handleResize);
+  document.removeEventListener("click", handleClickOutside);
 });
 </script>
 
@@ -382,21 +391,32 @@ onBeforeUnmount(() => {
 }
 
 .accessibility-toggle {
-  padding: 0.5rem;
+  padding: var(--space-3);
   background: transparent;
-  border: 2px solid rgb(74, 222, 128);
-  border-radius: 0.375rem;
-  color: rgb(74, 222, 128);
+  border: 2px solid var(--color-blue-500);
+  border-radius: var(--radius-md);
+  color: var(--color-blue-600);
   cursor: pointer;
-  transition: all 0.3s ease;
-  font-size: 1.2rem;
+  transition: var(--transition-base);
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .accessibility-toggle:hover,
 .accessibility-toggle:focus {
-  background-color: rgb(74, 222, 128);
-  color: rgb(15, 23, 42);
+  background-color: var(--color-blue-500);
+  color: var(--color-white);
   outline: none;
+  transform: scale(1.05);
+}
+
+.accessibility-toggle:focus-visible {
+  outline: 3px solid var(--color-blue-300);
+  outline-offset: 2px;
 }
 
 .accessibility-menu {
@@ -404,13 +424,15 @@ onBeforeUnmount(() => {
   top: 100%;
   right: 0;
   margin-top: 0.5rem;
-  background: white;
-  border: 1px solid var(--color-gray-300);
-  border-radius: 0.5rem;
-  box-shadow: var(--shadow-lg);
-  padding: 1rem;
-  min-width: 250px;
-  z-index: 1000;
+  background: var(--color-white);
+  border: 2px solid var(--color-gray-300);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-4);
+  min-width: 280px;
+  max-width: 320px;
+  z-index: 9999;
+  transform: translateX(0);
 }
 
 .accessibility-section {
@@ -422,34 +444,50 @@ onBeforeUnmount(() => {
 }
 
 .accessibility-title {
-  font-size: 0.875rem;
-  font-weight: 600;
+  font-size: 1rem;
+  font-weight: 700;
   color: var(--color-gray-900);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-gray-200);
+  padding-bottom: var(--space-2);
 }
 
 .accessibility-options {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-2);
 }
 
 .accessibility-option {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem;
+  gap: var(--space-3);
+  padding: var(--space-3);
   cursor: pointer;
-  border-radius: 0.25rem;
-  transition: background-color 0.2s;
+  border-radius: var(--radius-md);
+  transition: var(--transition-base);
+  border: 1px solid transparent;
 }
 
 .accessibility-option:hover {
   background-color: var(--color-gray-100);
+  border-color: var(--color-gray-300);
+}
+
+.accessibility-option:focus-within {
+  background-color: var(--color-blue-100);
+  border-color: var(--color-blue-500);
 }
 
 .accessibility-option input[type="radio"] {
   margin: 0;
+  width: 16px;
+  height: 16px;
+}
+
+.accessibility-option span {
+  font-weight: 500;
+  color: var(--color-gray-800);
 }
 
 .main-nav {
@@ -573,9 +611,28 @@ onBeforeUnmount(() => {
 }
 
 :root[data-color-scheme="dark"] .accessibility-menu {
-  background-color: #2d2d2d;
-  color: white;
-  border-color: #444;
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-900);
+  border-color: var(--color-gray-400);
+}
+
+:root[data-color-scheme="dark"] .accessibility-title {
+  color: var(--color-gray-900);
+  border-bottom-color: var(--color-gray-400);
+}
+
+:root[data-color-scheme="dark"] .accessibility-option span {
+  color: var(--color-gray-800);
+}
+
+:root[data-color-scheme="dark"] .accessibility-option:hover {
+  background-color: var(--color-gray-200);
+  border-color: var(--color-gray-500);
+}
+
+:root[data-color-scheme="dark"] .accessibility-option:focus-within {
+  background-color: var(--color-blue-200);
+  border-color: var(--color-blue-600);
 }
 
 :root[data-color-scheme="blue-yellow"] .nav-toggle-button,

--- a/src/components/NavBarComponent.vue
+++ b/src/components/NavBarComponent.vue
@@ -467,16 +467,17 @@ onBeforeUnmount(() => {
   border-radius: var(--radius-md);
   transition: var(--transition-base);
   border: 1px solid transparent;
+  background-color: transparent;
 }
 
 .accessibility-option:hover {
-  background-color: var(--color-gray-100);
-  border-color: var(--color-gray-300);
+  background-color: var(--color-green-100) !important;
+  border-color: var(--color-green-500);
 }
 
 .accessibility-option:focus-within {
-  background-color: var(--color-blue-100);
-  border-color: var(--color-blue-500);
+  background-color: var(--color-green-100) !important;
+  border-color: var(--color-green-500);
 }
 
 .accessibility-option input[type="radio"] {
@@ -487,6 +488,14 @@ onBeforeUnmount(() => {
 
 .accessibility-option span {
   font-weight: 500;
+  color: var(--color-gray-900) !important;
+}
+
+.accessibility-option:hover span {
+  color: var(--color-gray-900) !important;
+}
+
+.accessibility-option:focus-within span {
   color: var(--color-gray-900) !important;
 }
 
@@ -626,13 +635,21 @@ onBeforeUnmount(() => {
 }
 
 :root[data-color-scheme="dark"] .accessibility-option:hover {
-  background-color: var(--color-gray-200);
-  border-color: var(--color-gray-500);
+  background-color: var(--color-green-200) !important;
+  border-color: var(--color-green-600);
 }
 
 :root[data-color-scheme="dark"] .accessibility-option:focus-within {
-  background-color: var(--color-blue-200);
-  border-color: var(--color-blue-600);
+  background-color: var(--color-green-200) !important;
+  border-color: var(--color-green-600);
+}
+
+:root[data-color-scheme="dark"] .accessibility-option:hover span {
+  color: var(--color-gray-900) !important;
+}
+
+:root[data-color-scheme="dark"] .accessibility-option:focus-within span {
+  color: var(--color-gray-900) !important;
 }
 
 :root[data-color-scheme="blue-yellow"] .nav-toggle-button,
@@ -659,6 +676,50 @@ onBeforeUnmount(() => {
 .accessibility-option:focus-within {
   outline: 3px solid #4A90E2;
   outline-offset: 2px;
+}
+
+/* Accessibility settings */
+:root[data-text-size="small"] {
+  font-size: 14px;
+}
+
+:root[data-text-size="large"] {
+  font-size: 18px;
+}
+
+:root[data-contrast="high"] {
+  --color-gray-900: #000000;
+  --color-gray-800: #1a1a1a;
+  --color-gray-700: #333333;
+  --color-gray-600: #4a4a4a;
+  --color-gray-500: #666666;
+  --color-gray-400: #808080;
+  --color-gray-300: #999999;
+  --color-gray-200: #b3b3b3;
+  --color-gray-100: #cccccc;
+  --color-gray-50: #e6e6e6;
+}
+
+:root[data-color-scheme="dark"] {
+  --color-gray-50: #1f2937;
+  --color-gray-100: #374151;
+  --color-gray-200: #4b5563;
+  --color-gray-300: #6b7280;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #d1d5db;
+  --color-gray-600: #e5e7eb;
+  --color-gray-700: #f3f4f6;
+  --color-gray-800: #f9fafb;
+  --color-gray-900: #ffffff;
+}
+
+:root[data-color-scheme="blue-yellow"] {
+  --color-blue-500: #0066cc;
+  --color-blue-600: #0052a3;
+  --color-blue-700: #003d7a;
+  --color-green-500: #ffcc00;
+  --color-green-600: #e6b800;
+  --color-green-700: #cca300;
 }
 
 /* Reduced motion for users who prefer it */

--- a/src/components/NavBarComponent.vue
+++ b/src/components/NavBarComponent.vue
@@ -422,17 +422,16 @@ onBeforeUnmount(() => {
 .accessibility-menu {
   position: absolute;
   top: 100%;
-  right: -10px;
+  right: 0;
   margin-top: 0.5rem;
   background: var(--color-white);
   border: 2px solid var(--color-gray-300);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-xl);
   padding: var(--space-4);
-  min-width: 280px;
-  max-width: 320px;
+  width: 300px;
   z-index: 9999;
-  transform: translateX(0);
+  transform: translateX(calc(100% - 44px));
 }
 
 .accessibility-section {

--- a/src/style.css
+++ b/src/style.css
@@ -609,6 +609,15 @@ input[type="radio"]:checked + .radio-card {
     --color-red-700: #b91c1c;
 }
 
+/* Force background colors for default theme */
+:root[data-color-scheme="default"] body,
+:root[data-color-scheme="default"] .nav-container,
+:root[data-color-scheme="default"] .footer-container,
+:root[data-color-scheme="default"] .main-nav {
+    background-color: #ffffff !important;
+    color: #111827 !important;
+}
+
 /* Dark theme: White/Green on Dark */
 :root[data-color-scheme="dark"] {
     --color-white: #1f2937;
@@ -633,6 +642,15 @@ input[type="radio"]:checked + .radio-card {
     --color-red-700: #fecaca;
 }
 
+/* Force background colors for dark theme */
+:root[data-color-scheme="dark"] body,
+:root[data-color-scheme="dark"] .nav-container,
+:root[data-color-scheme="dark"] .footer-container,
+:root[data-color-scheme="dark"] .main-nav {
+    background-color: #1f2937 !important;
+    color: #ffffff !important;
+}
+
 /* Blue-Yellow theme: Blue on Yellow */
 :root[data-color-scheme="blue-yellow"] {
     --color-white: #ffcc00;
@@ -655,6 +673,15 @@ input[type="radio"]:checked + .radio-card {
     --color-red-500: #cc0000;
     --color-red-600: #aa0000;
     --color-red-700: #880000;
+}
+
+/* Force background colors for blue-yellow theme */
+:root[data-color-scheme="blue-yellow"] body,
+:root[data-color-scheme="blue-yellow"] .nav-container,
+:root[data-color-scheme="blue-yellow"] .footer-container,
+:root[data-color-scheme="blue-yellow"] .main-nav {
+    background-color: #ffcc00 !important;
+    color: #0066cc !important;
 }
 
 /* Réduction des animations pour les utilisateurs qui préfèrent */

--- a/src/style.css
+++ b/src/style.css
@@ -543,6 +543,79 @@ input[type="radio"]:checked + .radio-card {
     }
 }
 
+/* Accessibility settings - Text size for entire site */
+:root[data-text-size="small"] {
+    font-size: 14px;
+}
+
+:root[data-text-size="small"] * {
+    font-size: inherit;
+}
+
+:root[data-text-size="large"] {
+    font-size: 18px;
+}
+
+:root[data-text-size="large"] * {
+    font-size: inherit;
+}
+
+/* High contrast mode for entire site */
+:root[data-contrast="high"] {
+    --color-gray-900: #000000;
+    --color-gray-800: #1a1a1a;
+    --color-gray-700: #333333;
+    --color-gray-600: #4a4a4a;
+    --color-gray-500: #666666;
+    --color-gray-400: #808080;
+    --color-gray-300: #999999;
+    --color-gray-200: #b3b3b3;
+    --color-gray-100: #cccccc;
+    --color-gray-50: #e6e6e6;
+    --color-blue-500: #0066cc;
+    --color-blue-600: #004499;
+    --color-blue-700: #003366;
+    --color-green-500: #00aa00;
+    --color-green-600: #008800;
+    --color-green-700: #006600;
+    --color-red-500: #cc0000;
+    --color-red-600: #aa0000;
+    --color-red-700: #880000;
+}
+
+/* Color schemes for entire site */
+:root[data-color-scheme="dark"] {
+    --color-gray-50: #1f2937;
+    --color-gray-100: #374151;
+    --color-gray-200: #4b5563;
+    --color-gray-300: #6b7280;
+    --color-gray-400: #9ca3af;
+    --color-gray-500: #d1d5db;
+    --color-gray-600: #e5e7eb;
+    --color-gray-700: #f3f4f6;
+    --color-gray-800: #f9fafb;
+    --color-gray-900: #ffffff;
+}
+
+:root[data-color-scheme="blue-yellow"] {
+    --color-blue-500: #0066cc;
+    --color-blue-600: #0052a3;
+    --color-blue-700: #003d7a;
+    --color-green-500: #ffcc00;
+    --color-green-600: #e6b800;
+    --color-green-700: #cca300;
+    --color-gray-900: #000066;
+    --color-gray-800: #000080;
+    --color-gray-700: #0000aa;
+    --color-gray-600: #0000cc;
+    --color-gray-500: #0000ff;
+    --color-gray-400: #3333ff;
+    --color-gray-300: #6666ff;
+    --color-gray-200: #9999ff;
+    --color-gray-100: #ccccff;
+    --color-gray-50: #e6e6ff;
+}
+
 /* Réduction des animations pour les utilisateurs qui préfèrent */
 @media (prefers-reduced-motion: reduce) {
     *,

--- a/src/style.css
+++ b/src/style.css
@@ -77,6 +77,24 @@
         --color-gray-800: #f9fafb;
         --color-gray-900: #ffffff;
     }
+    /* Harmonisation des surfaces en mode sombre */
+    .card {
+        background-color: var(--color-gray-100);
+        border-color: var(--color-gray-300);
+    }
+    .radio-card {
+        background-color: var(--color-gray-100);
+        border-color: var(--color-gray-300);
+        color: var(--color-gray-900);
+    }
+    .radio-title { color: var(--color-gray-900); }
+    .radio-code { color: var(--color-gray-500); }
+    .card h1, .card p { color: var(--color-gray-900); }
+    .custom-button:not(.button-blue):not(.button-green):not(.button-red):not(.button-yellow) {
+        background-color: var(--color-gray-100);
+        border-color: var(--color-gray-300);
+        color: var(--color-gray-800);
+    }
 }
 
 * {
@@ -98,6 +116,23 @@ html, body {
     background-color: var(--color-gray-50);
     min-height: 100vh;
     scroll-behavior: smooth;
+}
+
+/* Skip link visible au focus uniquement, placé en haut de page */
+.skip-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translateY(-100%);
+    background: var(--color-blue-600);
+    color: var(--color-white);
+    padding: var(--space-2) var(--space-4);
+    border-radius: 0 0 var(--radius-md) 0;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    transform: translateY(0);
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -153,7 +188,7 @@ a:focus-visible {
     cursor: pointer;
     transition: var(--transition-base);
     background-color: var(--color-white);
-    color: var(--color-gray-800);
+    color: var(--color-gray-900);
     border: 1px solid var(--color-gray-300);
     position: relative;
     overflow: hidden;
@@ -351,6 +386,62 @@ a:focus-visible {
     margin: var(--space-4) 0;
 }
 
+/* Grille de sélection de langue */
+.language-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-4);
+    list-style: none;
+}
+
+.radio-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    width: 100%;
+    padding: var(--space-4);
+    border: 2px solid var(--color-gray-200);
+    border-radius: var(--radius-lg);
+    background: var(--color-white);
+    color: var(--color-gray-900);
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    transition: var(--transition-base);
+}
+
+.radio-card:hover {
+    border-color: var(--color-blue-500);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+
+.radio-card:focus-visible {
+    outline: 3px solid var(--color-blue-500);
+    outline-offset: 2px;
+}
+
+.radio-title {
+    font-weight: 600;
+    color: var(--color-gray-900);
+}
+
+.radio-code {
+    font-size: 0.75rem;
+    color: var(--color-gray-600);
+}
+
+/* État sélectionné (via input:checked + label) */
+input[type="radio"]:checked + .radio-card {
+    border-color: var(--color-blue-600);
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+/* Contraste texte dans les cartes et contenus de la page de langue */
+.card h1, .card p {
+    color: var(--color-gray-900);
+}
+
 /* Animations */
 @keyframes fadeIn {
     from { opacity: 0; transform: translateY(10px); }
@@ -441,4 +532,27 @@ a:focus-visible {
         transition-duration: 0.01ms !important;
         scroll-behavior: auto !important;
     }
+}
+
+/* Dark mode overrides (placed at end to win cascade) */
+@media (prefers-color-scheme: dark) {
+    .card {
+        background-color: var(--color-gray-100);
+        border-color: var(--color-gray-300);
+    }
+    .card h1,
+    .card p,
+    legend {
+        color: var(--color-gray-900);
+    }
+    fieldset {
+        border-color: var(--color-gray-400);
+    }
+    .radio-card {
+        background-color: var(--color-gray-100);
+        border-color: var(--color-gray-400);
+        color: var(--color-gray-900);
+    }
+    .radio-title { color: var(--color-gray-900); }
+    .radio-code { color: var(--color-gray-500); }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -389,8 +389,8 @@ a:focus-visible {
 /* Grille de sélection de langue */
 .language-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--space-6);
     list-style: none;
 }
 
@@ -400,7 +400,7 @@ a:focus-visible {
     justify-content: space-between;
     gap: var(--space-2);
     width: 100%;
-    padding: var(--space-4);
+    padding: var(--space-6);
     border: 2px solid var(--color-gray-200);
     border-radius: var(--radius-lg);
     background: var(--color-white);
@@ -408,6 +408,11 @@ a:focus-visible {
     box-shadow: var(--shadow-sm);
     cursor: pointer;
     transition: var(--transition-base);
+}
+
+/* Espace au-dessus de la zone d'actions (bouton Continue) */
+.language-actions {
+    margin-top: var(--space-6);
 }
 
 .radio-card:hover {

--- a/src/style.css
+++ b/src/style.css
@@ -584,36 +584,77 @@ input[type="radio"]:checked + .radio-card {
 }
 
 /* Color schemes for entire site */
-:root[data-color-scheme="dark"] {
-    --color-gray-50: #1f2937;
-    --color-gray-100: #374151;
-    --color-gray-200: #4b5563;
-    --color-gray-300: #6b7280;
+
+/* Default theme: Green/Black/Gray on White */
+:root[data-color-scheme="default"] {
+    --color-white: #ffffff;
+    --color-gray-50: #f9fafb;
+    --color-gray-100: #f3f4f6;
+    --color-gray-200: #e5e7eb;
+    --color-gray-300: #d1d5db;
     --color-gray-400: #9ca3af;
-    --color-gray-500: #d1d5db;
-    --color-gray-600: #e5e7eb;
-    --color-gray-700: #f3f4f6;
-    --color-gray-800: #f9fafb;
-    --color-gray-900: #ffffff;
+    --color-gray-500: #6b7280;
+    --color-gray-600: #4b5563;
+    --color-gray-700: #374151;
+    --color-gray-800: #1f2937;
+    --color-gray-900: #111827;
+    --color-blue-500: #10b981;
+    --color-blue-600: #059669;
+    --color-blue-700: #047857;
+    --color-green-500: #10b981;
+    --color-green-600: #059669;
+    --color-green-700: #047857;
+    --color-red-500: #ef4444;
+    --color-red-600: #dc2626;
+    --color-red-700: #b91c1c;
 }
 
+/* Dark theme: White/Green on Dark */
+:root[data-color-scheme="dark"] {
+    --color-white: #1f2937;
+    --color-gray-50: #111827;
+    --color-gray-100: #1f2937;
+    --color-gray-200: #374151;
+    --color-gray-300: #4b5563;
+    --color-gray-400: #6b7280;
+    --color-gray-500: #9ca3af;
+    --color-gray-600: #d1d5db;
+    --color-gray-700: #e5e7eb;
+    --color-gray-800: #f3f4f6;
+    --color-gray-900: #ffffff;
+    --color-blue-500: #10b981;
+    --color-blue-600: #34d399;
+    --color-blue-700: #6ee7b7;
+    --color-green-500: #10b981;
+    --color-green-600: #34d399;
+    --color-green-700: #6ee7b7;
+    --color-red-500: #f87171;
+    --color-red-600: #fca5a5;
+    --color-red-700: #fecaca;
+}
+
+/* Blue-Yellow theme: Blue on Yellow */
 :root[data-color-scheme="blue-yellow"] {
+    --color-white: #ffcc00;
+    --color-gray-50: #fff7cc;
+    --color-gray-100: #ffed99;
+    --color-gray-200: #ffe366;
+    --color-gray-300: #ffd933;
+    --color-gray-400: #ffcc00;
+    --color-gray-500: #e6b800;
+    --color-gray-600: #cca300;
+    --color-gray-700: #b38f00;
+    --color-gray-800: #997a00;
+    --color-gray-900: #0066cc;
     --color-blue-500: #0066cc;
     --color-blue-600: #0052a3;
     --color-blue-700: #003d7a;
-    --color-green-500: #ffcc00;
-    --color-green-600: #e6b800;
-    --color-green-700: #cca300;
-    --color-gray-900: #000066;
-    --color-gray-800: #000080;
-    --color-gray-700: #0000aa;
-    --color-gray-600: #0000cc;
-    --color-gray-500: #0000ff;
-    --color-gray-400: #3333ff;
-    --color-gray-300: #6666ff;
-    --color-gray-200: #9999ff;
-    --color-gray-100: #ccccff;
-    --color-gray-50: #e6e6ff;
+    --color-green-500: #0066cc;
+    --color-green-600: #0052a3;
+    --color-green-700: #003d7a;
+    --color-red-500: #cc0000;
+    --color-red-600: #aa0000;
+    --color-red-700: #880000;
 }
 
 /* Réduction des animations pour les utilisateurs qui préfèrent */

--- a/src/style.css
+++ b/src/style.css
@@ -386,12 +386,28 @@ a:focus-visible {
     margin: var(--space-4) 0;
 }
 
+/* Améliorer lisibilité fieldset/legend */
+fieldset {
+    border: 1px solid var(--color-gray-300);
+    border-radius: var(--radius-md);
+    padding: var(--space-6);
+    margin-top: var(--space-4);
+}
+
+legend {
+    padding: 0 var(--space-2);
+    font-weight: 600;
+    color: var(--color-gray-900);
+    margin-bottom: var(--space-2);
+}
+
 /* Grille de sélection de langue */
 .language-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: var(--space-6);
     list-style: none;
+    margin-top: var(--space-2);
 }
 
 .radio-card {


### PR DESCRIPTION
## Problem

- Language selection page had poor readability (low contrast, faint labels).
- Missing global accessibility scaffolding (skip link, HTML `lang`, route change announcements).
- Keyboard navigation on the language screen was not fully accessible (no proper radio group).

## Solution

- Global a11y scaffolding:
  - Add skip link (“Skip to main content”).
  - Sync `html[lang]` with the selected locale.
  - Add `aria-live` region to announce route changes.
- Language selection redesign:
  - Accessible form with `form` + `fieldset`/`legend` + radio inputs.
  - Clickable cards via associated `<label>`; visible focus states.
  - “Continue” button stays disabled until a language is selected.
  - High-contrast styles for light and dark modes (cards, titles, codes, legend).
- Minor design polish (spacing, shadows, consistent visuals).

Main files:
- `index.html`, `src/App.vue`, `src/style.css`

## Note

- Lint: 0 errors (a few non-blocking Vue attribute-order warnings).
- No business logic changes; UI-only.
- Colors aim for strong contrast; we can further tweak after user feedback (VO/NVDA).

## Test
1) Start
- `npm run dev`
- Open `http://localhost:5173/#/`
- Click “Reset all cookies” to reach the language screen.

2) Keyboard a11y
- Press Tab: skip link appears; Enter jumps to main content.
- Tab to language cards: focus ring is visible.
- Space/Enter selects a language (radio).
- “Continue” enables after selection; Enter submits.

3) Screen reader (VO/NVDA/JAWS)
- Confirm `legend` (“Available languages”) and options are announced.
- Changing the language re-announces the page title via `aria-live`.

4) Contrast and themes
- Test light/dark (system preference).
- Ensure titles, descriptions, codes (EN/FR/ES/IT), and button are readable.
- Check focus outline and selected state (checked radio).

5) Reduced motion
- Enable “Reduce motion” in OS; animations should be minimized.

6) Non-regression
- After selecting a language, the app continues to work (navbar, views, i18n).
