### PR TITLE
fix(workflow): start pr title check when edited pull request

### DIFF
--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -2,7 +2,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, edited]
     branches:
       - main
 


### PR DESCRIPTION
This pull request makes a small update to the pull request title check workflow. The workflow now runs when a pull request is edited, instead of when it is synchronized.

* [`.github/workflows/PR Title Check.yml`](diffhunk://#diff-e6d2be8389bd688a7879afcde237f873c599b6d1fe794a6a4352e4a428192e93L5-R5): Changed the workflow trigger from `synchronize` to `edited` in the `types` list for pull request events.