### PR TITLE
tech: Remove the report contact form flag

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,18 +1,12 @@
 <script setup>
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ReportContactForm from "@/components/ReportContactForm.vue";
-import { useFlags } from "@/stores/flags-store.js";
 import { useHead } from "#imports";
 
 const { t } = useI18n();
-const flagsStore = useFlags();
 
-const showContactForm = computed(() => {
-  const flag = flagsStore.getFlag("show-contact-form");
-  return flag;
-});
 useHead({
   title: () => `${t("about.title")} | ${t("title")}`,
 });
@@ -48,7 +42,7 @@ const links = ref({
       </div>
     </section>
   </div>
-  <div v-if="showContactForm">
+  <div>
     <ReportContactForm/>
   </div>
 </template>

--- a/sample.env
+++ b/sample.env
@@ -36,8 +36,3 @@ MAILING_PASSWORD=yourpassword
 USE_VERCEL_FLAGS=false
 
 # Local flags (used when USE_VERCEL_FLAGS is false)
-# SHOW_CONTACT_FORM: Show the report contact form on the website (true/false)
-# Vercel name: show-contact-form
-# Type: boolean
-# Default: false
-FLAG_SHOW_CONTACT_FORM=true

--- a/server/api/flags.js
+++ b/server/api/flags.js
@@ -5,10 +5,10 @@ import { config } from "@/server/config.js";
 
 export default defineEventHandler(async () => {
   return {
-    "show-contact-form": await _getFlagType("show-contact-form", false),
   };
 });
 
+// eslint-disable-next-line no-unused-vars
 async function _getFlagType(flagName, flagDefault) {
   const returningFlag = config.useVercelFlags
     ? await flagsClient.evaluate(flagName, flagDefault)

--- a/server/config.js
+++ b/server/config.js
@@ -19,6 +19,7 @@ function toBoolean(value) {
  * This is a helper function to be used in Vercel's feature flags. It returns an object with a "value" property set to the provided flag value.
  * @param flag - The value of the feature flag to be returned in the object.
  */
+// eslint-disable-next-line no-unused-vars
 function getToFlag(flag) {
   return { value: flag };
 }
@@ -39,7 +40,7 @@ const configuration = (function() {
     },
     useVercelFlags: toBoolean(process.env.USE_VERCEL_FLAGS),
     flags: {
-      "show-contact-form": getToFlag(toBoolean(process.env.FLAG_SHOW_CONTACT_FORM)),
+      // Example of a feature flag that can be toggled on or off using Vercel's feature flags.
     },
   };
   if (config.environment === "test") {


### PR DESCRIPTION
This pull request removes the "show-contact-form" feature flag from the codebase, making the report contact form always visible on the About page. The related configuration, environment variable, and server-side logic for this flag have also been cleaned up.

Feature flag removal and UI update:

* The computed property and store usage for the `show-contact-form` flag were removed from the `about.vue` page, and the contact form is now always rendered. [[1]](diffhunk://#diff-b10942e88a1a75cc0044cdafd5a2b6dc81068901722be8708978731fefee6eb3L2-L15) [[2]](diffhunk://#diff-b10942e88a1a75cc0044cdafd5a2b6dc81068901722be8708978731fefee6eb3L51-R45)
* The `FLAG_SHOW_CONTACT_FORM` environment variable and its documentation were removed from `sample.env`.

Server-side cleanup:

* The `show-contact-form` flag was removed from the API response in `server/api/flags.js`.
* The flag was also removed from the configuration object in `server/config.js`.
* The unused `getToFlag` helper function was annotated to suppress lint warnings about unused variables.