### PR TITLE
fix: Fix the release rules and remove one section

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -1,9 +1,9 @@
 name: Back Merge Main into Production
 
 on:
-  push:
-    branches:
-      - production
+  release:
+    types:
+      - released
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,5 @@ jobs:
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
+            @semantic-release/exec
             conventional-changelog-conventionalcommits

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -53,6 +53,12 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version"
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -33,7 +33,6 @@
             { "type": "breaking", "section": "💥 Breaking changes" },
             { "type": "feat", "section": "🚀 New features" },
             { "type": "fix", "section": "🐛 Bug fixes" },
-            { "type": "chore", "section": "🔧 Chore" },
             { "type": "docs", "section": "📚 Documentation" },
             { "type": "style", "section": "💅 Styles" },
             { "type": "refactor", "section": "🔨 Refactor" },


### PR DESCRIPTION
- **fix: run back merge only on released release**
- **fix: update npm version when released**
- **tech: remove chore section**

## Problem

- When one commit was pushed on production branch, the workflow was triggered and when tag was pushed, there wasn't a 2nd workflow triggering.
- The chore section was apeared on the changelog and it's not necessary because chore commits are release commits.
- The project version was not actualize with new tag.

## Solution

- Fix the workflow to trigger only when a release is released (not prereleased),
- Remove chore section on release types,
- Add a exec command to update project version when taging.