### PR TITLE
test: Fix tests for emails

### DIFF
--- a/tests/unit/server/email/send-mail-service.spec.js
+++ b/tests/unit/server/email/send-mail-service.spec.js
@@ -70,6 +70,7 @@ describe("Unit | Shared | Services | Send mail", () => {
   describe("when mail is enabled", () => {
     beforeEach(() => {
       email.enabled = true;
+      email.testAccount = false;
     });
     it("should send email correctly with text", async () => {
       // given


### PR DESCRIPTION
This pull request makes a small change to the email service unit tests. The change ensures that the `testAccount` property is set to `false` when mail is enabled, providing a more accurate test environment.

- Set `email.testAccount` to `false` in the `beforeEach` block for tests where mail is enabled (`tests/unit/server/email/send-mail-service.spec.js`).